### PR TITLE
Fixed host and pathname handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = fp(function from (fastify, opts, next) {
     cache.set(source, url)
 
     var headers = req.headers
+    headers.host = url.hostname
     const queryString = getQueryString(url.search, req.url, opts)
     var body = ''
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "fastify": "^0.43.0",
     "msgpack5": "^4.0.1",
+    "nock": "^9.1.6",
     "pre-commit": "^1.2.2",
     "simple-get": "^2.7.0",
     "snazzy": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "bugs": {
     "url": "https://github.com/fastify/fastify-reply-from/issues"
   },
-  "engines" : {
-    "node" : ">=8.0.0"
+  "engines": {
+    "node": ">=8.0.0"
   },
   "homepage": "https://github.com/fastify/fastify-reply-from#readme",
   "devDependencies": {

--- a/test/base-path.js
+++ b/test/base-path.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+
+t.plan(5)
+t.tearDown(instance.close.bind(instance))
+
+instance.get('/', (request, reply) => {
+  reply.from('http://httpbin.org/ip')
+})
+
+instance.register(From)
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['content-type'], 'application/json')
+    t.strictEqual(typeof JSON.parse(data).origin, 'string')
+  })
+})

--- a/test/base-path.js
+++ b/test/base-path.js
@@ -4,10 +4,18 @@ const t = require('tap')
 const Fastify = require('fastify')
 const From = require('..')
 const get = require('simple-get').concat
+const nock = require('nock')
 
 const instance = Fastify()
 
-t.plan(5)
+nock('http://httpbin.org')
+  .get('/ip')
+  .reply(function (uri, requestBody) {
+    t.is(this.req.headers.host, 'httpbin.org')
+    return { origin: '127.0.0.1' }
+  })
+
+t.plan(6)
 t.tearDown(instance.close.bind(instance))
 
 instance.get('/', (request, reply) => {

--- a/test/host-header.js
+++ b/test/host-header.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+
+t.plan(9)
+t.tearDown(instance.close.bind(instance))
+
+instance.get('*', (request, reply) => {
+  reply.from()
+})
+
+instance.register(From, {
+  base: 'http://httpbin.org/ip'
+})
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['content-type'], 'application/json')
+    t.strictEqual(typeof JSON.parse(data).origin, 'string')
+  })
+
+  get(`http://localhost:${instance.server.address().port}/ip`, (err, res, data) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['content-type'], 'application/json')
+    t.strictEqual(typeof JSON.parse(data).origin, 'string')
+  })
+})

--- a/test/host-header.js
+++ b/test/host-header.js
@@ -4,10 +4,18 @@ const t = require('tap')
 const Fastify = require('fastify')
 const From = require('..')
 const get = require('simple-get').concat
+const nock = require('nock')
 
 const instance = Fastify()
 
-t.plan(9)
+nock('http://httpbin.org')
+  .get('/ip')
+  .reply(function (uri, requestBody) {
+    t.is(this.req.headers.host, 'httpbin.org')
+    return { origin: '127.0.0.1' }
+  })
+
+t.plan(6)
 t.tearDown(instance.close.bind(instance))
 
 instance.get('*', (request, reply) => {
@@ -20,13 +28,6 @@ instance.register(From, {
 
 instance.listen(0, (err) => {
   t.error(err)
-
-  get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
-    t.error(err)
-    t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-type'], 'application/json')
-    t.strictEqual(typeof JSON.parse(data).origin, 'string')
-  })
 
   get(`http://localhost:${instance.server.address().port}/ip`, (err, res, data) => {
     t.error(err)


### PR DESCRIPTION
As titled.
Both fixes are tested in `test/host-header.js`.