### PR TITLE
reset request body when proxy get request from fastify

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = fp(function from (fastify, opts, next) {
     // when proxy this request, we should reset the content-length to make it a valid http request
     // discussion: https://github.com/fastify/fastify/issues/953
     if (req.method === 'GET') {
-      headers['content-length'] = Buffer.byteLength(body)
+      headers['content-length'] = 0
     }
 
     req.log.info({ source }, 'fetching from remote server')

--- a/index.js
+++ b/index.js
@@ -61,6 +61,14 @@ module.exports = fp(function from (fastify, opts, next) {
       }
     }
 
+    // according to https://tools.ietf.org/html/rfc2616#section-4.3
+    // fastify ignore message body when it's a GET request
+    // when proxy this request, we should reset the content-length to make it a valid http request
+    // discussion: https://github.com/fastify/fastify/issues/953
+    if (req.method === 'GET') {
+      headers['content-length'] = Buffer.byteLength(body)
+    }
+
     req.log.info({ source }, 'fetching from remote server')
 
     request({ method: req.method, url, qs, headers, body }, (err, res) => {

--- a/test/get-with-body.js
+++ b/test/get-with-body.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+
+t.plan(12)
+t.tearDown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/')
+  t.equal(req.headers['content-length'], '0')
+  t.equal(req.body, undefined)
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/', (request, reply) => {
+  reply.from()
+})
+
+t.tearDown(target.close.bind(target))
+
+target.listen(0, (err) => {
+  t.error(err)
+
+  instance.register(From, {
+    base: `http://localhost:${target.address().port}`
+  })
+
+  instance.listen(0, (err) => {
+    t.error(err)
+
+    get({
+      url: `http://localhost:${instance.server.address().port}`,
+      method: 'GET',
+      body: 'this is get body'
+    }, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})


### PR DESCRIPTION
according to https://tools.ietf.org/html/rfc2616#section-4.3. fastify ignore message body when it's a GET request. when proxy this request, we should reset the content-length to make it a valid http request discussion: https://github.com/fastify/fastify/issues/953
 