### PR TITLE
fix ignore queryString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
+.vscode/

--- a/index.js
+++ b/index.js
@@ -115,12 +115,12 @@ module.exports = fp(function from (fastify, opts, next) {
 }, '>= 1.3.0')
 
 function getQueryString (search, reqUrl, opts) {
-  if (search.length > 0) {
-    return search
-  }
-
   if (opts.queryString) {
     return '?' + querystring.stringify(opts.queryString)
+  }
+
+  if (search.length > 0) {
+    return search
   }
 
   const queryIndex = reqUrl.indexOf('?')

--- a/test/full-querystring-rewrite-option-complex.js
+++ b/test/full-querystring-rewrite-option-complex.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+
+t.plan(10)
+t.tearDown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/world?b=c')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/hello', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}/world?a=b`, {
+    queryString: { b: 'c' }
+  })
+})
+
+t.tearDown(target.close.bind(target))
+
+target.listen(0, (err) => {
+  t.error(err)
+
+  instance.register(From)
+
+  instance.listen(0, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}/hello?a=b`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})


### PR DESCRIPTION
fix ignore queryString when request a source contains url.search.

This is the first step to fix, potential need migrate to `queryString` function as @mcollina suggest.