### PR TITLE
Fix incorrect content-length and content-type for padded bodies

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ module.exports = fp(function from (fastify, opts, next) {
         body = this.request.body
       } else {
         body = JSON.stringify(this.request.body)
+        headers['content-length'] = Buffer.byteLength(body)
+        headers['content-type'] = 'application/json'
       }
     }
 

--- a/test/padded-body.js
+++ b/test/padded-body.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From)
+
+t.plan(9)
+t.tearDown(instance.close.bind(instance))
+
+const bodyString = `{
+  "hello": "world"
+}`
+
+const parsedLength = Buffer.byteLength(JSON.stringify(JSON.parse(bodyString)))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'POST')
+  t.equal(req.headers['content-type'], 'application/json')
+  t.same(req.headers['content-length'], parsedLength)
+  var data = ''
+  req.setEncoding('utf8')
+  req.on('data', (d) => {
+    data += d
+  })
+  req.on('end', () => {
+    t.same(JSON.parse(data), { hello: 'world' })
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ something: 'else' }))
+  })
+})
+
+instance.post('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`)
+})
+
+t.tearDown(target.close.bind(target))
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(0, (err) => {
+    t.error(err)
+
+    get({
+      url: `http://localhost:${instance.server.address().port}`,
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: bodyString
+    }, (err, res, data) => {
+      t.error(err)
+      const parsed = JSON.parse(data)
+      t.deepEqual(parsed, { something: 'else' })
+    })
+  })
+})


### PR DESCRIPTION
If an incoming request has a JSON-stringified body with non-zero spacing, the content length will be incorrect after parsing/stringifying it.

Since the headers are just forwarded, the content-length header will have an incorrect number of bytes, and will result in the target server either hanging when waiting for more bytes, or truncating the body if there are less bytes than specified.

This recalculates the length of the body, and sets the type as well (this should be json since it is stringifed by JSON, right?)