### PR TITLE
Change onresponse contract to allow request, reply, and res.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ instance with a `from` method, which will reply to the original request
 __from the desired source__. The options allows to override any part of
 the request or response being sent or received to/from the source.
 
-#### onResponse(res)
+#### onResponse(request, reply, res)
 
 Called when an http response is received from the source.
 The default behavior is `reply.send(res)`, which will be disabled if the

--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ const lru = require('tiny-lru')
 const querystring = require('querystring')
 const Stream = require('stream')
 const buildRequest = require('./lib/request')
-const { filterPseudoHeaders, copyHeaders, stripHttp1ConnectionHeaders } = require('./lib/utils')
+const {
+  filterPseudoHeaders,
+  copyHeaders,
+  stripHttp1ConnectionHeaders
+} = require('./lib/utils')
 
 module.exports = fp(function from (fastify, opts, next) {
   const cache = lru(opts.cacheURLs || 100)
@@ -94,13 +98,16 @@ module.exports = fp(function from (fastify, opts, next) {
       }
       this.request.log.info('response received')
       if (sourceHttp2) {
-        copyHeaders(rewriteHeaders(stripHttp1ConnectionHeaders(res.headers)), this)
+        copyHeaders(
+          rewriteHeaders(stripHttp1ConnectionHeaders(res.headers)),
+          this
+        )
       } else {
         copyHeaders(rewriteHeaders(res.headers), this)
       }
       this.code(res.statusCode)
       if (onResponse) {
-        onResponse(res.stream)
+        onResponse(this.request.req, this, res.stream)
       } else {
         this.send(res.stream)
       }

--- a/test/transform-body.js
+++ b/test/transform-body.js
@@ -24,31 +24,38 @@ const target = http.createServer((req, res) => {
 
 instance.get('/', (request, reply) => {
   reply.from(`http://localhost:${target.address().port}`, {
-    onResponse: (res) => {
-      reply.send(res.pipe(new Transform({
-        transform: function (chunk, enc, cb) {
-          this.push(chunk.toString().toUpperCase())
-          cb()
-        }
-      })))
+    onResponse: (request, reply, res) => {
+      reply.send(
+        res.pipe(
+          new Transform({
+            transform: function (chunk, enc, cb) {
+              this.push(chunk.toString().toUpperCase())
+              cb()
+            }
+          })
+        )
+      )
     }
   })
 })
 
 t.tearDown(target.close.bind(target))
 
-instance.listen(0, (err) => {
+instance.listen(0, err => {
   t.error(err)
 
-  target.listen(0, (err) => {
+  target.listen(0, err => {
     t.error(err)
 
-    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
-      t.error(err)
-      t.equal(res.headers['content-type'], 'text/plain')
-      t.equal(res.headers['x-my-header'], 'hello!')
-      t.equal(res.statusCode, 205)
-      t.equal(data.toString(), 'HELLO WORLD')
-    })
+    get(
+      `http://localhost:${instance.server.address().port}`,
+      (err, res, data) => {
+        t.error(err)
+        t.equal(res.headers['content-type'], 'text/plain')
+        t.equal(res.headers['x-my-header'], 'hello!')
+        t.equal(res.statusCode, 205)
+        t.equal(data.toString(), 'HELLO WORLD')
+      }
+    )
   })
 })


### PR DESCRIPTION
This is my attempt to allow `replyOptions` to work in `fastify-http-proxy`. The PR in question is here: https://github.com/fastify/fastify-http-proxy/pull/34

The only way that I am able to get this to work is to change the contract in `fastify-reply-from` so that `request, reply, res` are all available. If this is acceptable let me know and I will update the other reply with the appropriate test. 

Thanks again!