### PR TITLE
Allow overwrite request client

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const {
 module.exports = fp(function from (fastify, opts, next) {
   const cache = lru(opts.cacheURLs || 100)
   const base = opts.base
-  const { request, close } = buildRequest({
+  const { request: defaultRequest, close } = buildRequest({
     http2: !!opts.http2,
     base,
     keepAliveMsecs: opts.keepAliveMsecs,
@@ -24,11 +24,13 @@ module.exports = fp(function from (fastify, opts, next) {
     rejectUnauthorized: opts.rejectUnauthorized,
     undici: opts.undici
   })
+
   fastify.decorateReply('from', function (source, opts) {
-    opts = opts || {}
+    opts = Object.assign({ request: defaultRequest }, opts)
     const req = this.request.req
     const onResponse = opts.onResponse
     const rewriteHeaders = opts.rewriteHeaders || headersNoOp
+    const request = opts.request
 
     if (!source) {
       source = req.url

--- a/test/overwrite-request.js
+++ b/test/overwrite-request.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+const buildRequest = require('../lib/request')
+
+const instance = Fastify()
+
+t.plan(10)
+t.tearDown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/', (req, reply) => {
+  const { request } = buildRequest({})
+
+  reply.from(`http://localhost:${target.address().port}/`, {
+    request // <--- override request client
+  })
+})
+
+t.tearDown(target.close.bind(target))
+
+target.listen(0, (err) => {
+  t.error(err)
+
+  instance.register(From)
+
+  instance.listen(0, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})


### PR DESCRIPTION
Optionally allow the `request http client` overwrite in `from` call.
This extension will allow to proxy requests to different target APIs using the same plugin instance. 

Example use case: https://www.npmjs.com/package/k-fastify-gateway