### PR TITLE
Add `rewriteRequestHeaders` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Called to rewrite the headers of the response, before them being copied
 over to the outer response.
 It must return the new headers object.
 
+#### rewriteRequestHeaders(originalReq, headers)
+
+Called to rewrite the headers of the request, before them being sent to the other server.
+It must return the new headers object.
+
 #### queryString
 
 Replaces the original querystring of the request with what is specified.

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = fp(function from (fastify, opts, next) {
     const req = this.request.req
     const onResponse = opts.onResponse
     const rewriteHeaders = opts.rewriteHeaders || headersNoOp
+    const rewriteRequestHeaders = opts.rewriteRequestHeaders || requestHeadersNoOp
 
     if (!source) {
       source = req.url
@@ -84,7 +85,9 @@ module.exports = fp(function from (fastify, opts, next) {
 
     req.log.info({ source }, 'fetching from remote server')
 
-    request({ method: req.method, url, qs, headers, body }, (err, res) => {
+    const requestHeaders = rewriteRequestHeaders(req, headers)
+
+    request({ method: req.method, url, qs, headers: requestHeaders, body }, (err, res) => {
       if (err) {
         this.request.log.warn(err, 'response errored')
         if (!this.sent) {
@@ -143,5 +146,9 @@ function getQueryString (search, reqUrl, opts) {
 }
 
 function headersNoOp (headers) {
+  return headers
+}
+
+function requestHeadersNoOp (originalReq, headers) {
   return headers
 }

--- a/test/rewrite-request-headers.js
+++ b/test/rewrite-request-headers.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From)
+
+t.plan(9)
+t.tearDown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.end(req.headers.host)
+})
+
+instance.get('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`, {
+    rewriteRequestHeaders: (originalReq, headers) => {
+      t.pass('rewriteRequestHeaders called')
+      return Object.assign(headers, { host: 'host-override' })
+    }
+  })
+})
+
+t.tearDown(target.close.bind(target))
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(0, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'host-override')
+    })
+  })
+})


### PR DESCRIPTION
A new option allows to rewrite the request headers before sending them to the upstream server.

Closes #56 