### PR TITLE
Add support for unix socket destination server

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ target.listen(3001, (err) => {
 Set the base URL for all the forwarded requests. Will be required if `http2` is set to `true`
 Note that _every path will be discarded_.
 
+Custom URL protocols `unix+http:` and `unix+https:` can be used to forward requests to a unix
+socket server by using `querystring.escape(socketPath)` as the hostname.  This is not supported
+for http2 nor unidici.  To illustrate:
+
+```js
+const socketPath = require('querystring').escape('/run/http-daemon.socket')
+proxxy.register(require('fastify-reply-from'), {
+  base: 'unix+http://${socketPath}/'
+});
+```
+
 #### `http`
 By default, Node's [`http.request`](https://nodejs.org/api/http.html#http_http_request_options_callback)
 will be used if you don't enable [`http2`](#http2) or [`undici`](#undici). To customize the `request`,

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,6 +2,7 @@
 const semver = require('semver')
 const http = require('http')
 const https = require('https')
+const querystring = require('querystring')
 const eos = require('end-of-stream')
 const pump = require('pump')
 const undici = require('undici')
@@ -14,7 +15,9 @@ function buildRequest (opts) {
   const isUndici = !!opts.undici
   const requests = {
     'http:': http,
-    'https:': https
+    'https:': https,
+    'unix+http:': { base: http, request: unixRequest },
+    'unix+https:': { base: https, request: unixRequest }
   }
   const baseUrl = opts.base
   const http2Opts = getHttp2Opts(opts)
@@ -29,6 +32,9 @@ function buildRequest (opts) {
       throw new Error('Http2 support requires Node version >= 9.0.0')
     }
     if (!opts.base) throw new Error('Option base is required when http2 is true')
+    if (opts.base.startsWith('unix+')) {
+      throw new Error('Unix socket destination is not supported when http2 is true')
+    }
   } else {
     agents = {
       'http:': new http.Agent(httpOpts.agentOptions),
@@ -40,6 +46,9 @@ function buildRequest (opts) {
     http2 = getHttp2()
     return { request: handleHttp2Req, close }
   } else if (isUndici) {
+    if (opts.base.startsWith('unix+')) {
+      throw new Error('Unix socket destination is not supported when undici is enabled')
+    }
     if (typeof opts.undici !== 'object') {
       opts.undici = {}
     }
@@ -67,7 +76,7 @@ function buildRequest (opts) {
       path: opts.url.pathname + opts.qs,
       hostname: opts.url.hostname,
       headers: opts.headers,
-      agent: agents[opts.url.protocol],
+      agent: agents[opts.url.protocol.replace(/^unix:/, '')],
       ...httpOpts.requestOptions
     })
     req.on('error', done)
@@ -155,6 +164,13 @@ function buildRequest (opts) {
 
 module.exports = buildRequest
 module.exports.TimeoutError = TimeoutError
+
+function unixRequest (opts) {
+  delete opts.port
+  opts.socketPath = querystring.unescape(opts.hostname)
+  delete opts.hostname
+  return this.base.request(opts)
+}
 
 function end (req, body, cb) {
   if (!body || typeof body === 'string' || body instanceof Uint8Array) {

--- a/test/unix-http.js
+++ b/test/unix-http.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const fs = require('fs')
+const querystring = require('querystring')
+const http = require('http')
+const get = require('simple-get').concat
+
+if (process.platform === 'win32') {
+  t.pass()
+  process.exit(0)
+}
+
+const instance = Fastify()
+instance.register(From)
+
+t.plan(10)
+t.tearDown(instance.close.bind(instance))
+
+const socketPath = `${__filename}.socket`
+
+try {
+  fs.unlinkSync(socketPath)
+} catch (_) {
+}
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/hello')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/', (request, reply) => {
+  reply.from(`unix+http://${querystring.escape(socketPath)}/hello`)
+})
+
+t.tearDown(target.close.bind(target))
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(socketPath, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})

--- a/test/unix-https.js
+++ b/test/unix-https.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const https = require('https')
+const get = require('simple-get').concat
+const fs = require('fs')
+const querystring = require('querystring')
+const path = require('path')
+const certs = {
+  key: fs.readFileSync(path.join(__dirname, 'fixtures', 'fastify.key')),
+  cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'fastify.cert'))
+}
+
+if (process.platform === 'win32') {
+  t.pass()
+  process.exit(0)
+}
+
+const instance = Fastify({
+  https: certs
+})
+instance.register(From)
+
+t.plan(10)
+t.tearDown(instance.close.bind(instance))
+
+const socketPath = `${__filename}.socket`
+
+try {
+  fs.unlinkSync(socketPath)
+} catch (_) {
+}
+
+const target = https.createServer(certs, (req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/hello')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/', (request, reply) => {
+  reply.from(`unix+https://${querystring.escape(socketPath)}/hello`)
+})
+
+t.tearDown(target.close.bind(target))
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(socketPath, (err) => {
+    t.error(err)
+
+    get({
+      url: `https://localhost:${instance.server.address().port}`,
+      rejectUnauthorized: false
+    }, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})


### PR DESCRIPTION
This is not ready for merge as tests / documentation are needed, at this time I'm really just looking for feedback on the proposed API.  I can confirm `unix+http` works, I've used this branch to replace the `fastify-reply-from` used by `fastify-http-proxy`, the following is an example initialization:
```js
fastify.register(fastifyHttpProxy, {
  upstream: `unix+http://${querystring.escape(runDir('http.sock'))}/`,
  prefix: this.prefix
});
```

I got the idea of encoding the path as hostname from a [CURL thread](https://curl.haxx.se/mail/lib-2008-04/0280.html).  The separate `unix+http` protocol is easier to detect and should not impose a performance cost on TCP hostname based requests.  Also `unix+http` avoids potential ambiguity if someone uses a socket file in `cwd` such as `unix+http://file.sock/resource`, this will not attempt to load from the `file.sock` hostname.

Worth noting I have not tested the `unix+https` functionality.  I'm not sure this is even possible and if it is I'm not convinced it's useful.  I'd be open to dropping `unix+https` from the initial patch, let someone else add that if they find a use for it.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
