### PR TITLE
Introduce http & http2 options with timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ typings/
 .env
 
 .vscode/
+
+# lockfiles
+yarn.lock
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -59,17 +59,6 @@ target.listen(3001, (err) => {
 
 ## API
 
-### Timeout
-
-This library has:
-- `timeout` for `http` set by default. The default value is 10 seconds (`10000`).
-- `requestTimeout` & `sessionTimeout` for `http2` set by default.
-  - The default value for `requestTimeout` is 10 seconds (`10000`).
-  - The default value for `sessionTimeout` is 60 seconds (`60000`).
-
-When a timeout happens, [`504 Gateway Timeout`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
-will be returned to the client.
-
 ### Plugin options
 
 #### `base`
@@ -209,6 +198,19 @@ Setting this option will not verify if the http method allows for a body.
 
 Override the `'Content-Type'` header of the forwarded request, if we are
 already overriding the [`body`][body].
+
+---
+
+#### Timeout
+
+This library has:
+- `timeout` for `http` set by default. The default value is 10 seconds (`10000`).
+- `requestTimeout` & `sessionTimeout` for `http2` set by default.
+  - The default value for `requestTimeout` is 10 seconds (`10000`).
+  - The default value for `sessionTimeout` is 60 seconds (`60000`).
+
+When a timeout happens, [`504 Gateway Timeout`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
+will be returned to the client.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,7 @@ Setting this option will not verify if the http method allows for a body.
 Override the `'Content-Type'` header of the forwarded request, if we are
 already overriding the [`body`][body].
 
----
-
-#### Timeout
+### HTTP & HTTP2 timeouts
 
 This library has:
 - `timeout` for `http` set by default. The default value is 10 seconds (`10000`).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This library has:
 - `timeout` for `http` set by default. The default value is 10 seconds (`10000`).
 - `requestTimeout` & `sessionTimeout` for `http2` set by default.
   - The default value for `requestTimeout` is 10 seconds (`10000`).
-  - The default value for `requestTimeout` is 60 seconds (`60000`).
+  - The default value for `sessionTimeout` is 60 seconds (`60000`).
 
 When a timeout happens, [`504 Gateway Timeout`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
 will be returned to the client.

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,11 @@ import {
 
 declare function fastifyReplyFrom<HttpServer, HttpRequest, HttpResponse>(
   instance: fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>,
-  opts?: fastifyReplyFrom.ReplyFromOptions,
+  opts: fastifyReplyFrom.ReplyFromOptions<
+    HttpServer,
+    HttpRequest,
+    HttpResponse
+  >,
   callback?: (err?: Error) => void
 ): void;
 
@@ -37,7 +41,8 @@ interface HttpOptions {
 }
 
 declare namespace fastifyReplyFrom {
-  interface ReplyFromOptions {
+  interface ReplyFromOptions<HttpServer, HttpRequest, HttpResponse>
+    extends fastify.RegisterOptions<HttpServer, HttpRequest, HttpResponse> {
     base?: string;
     cacheURLs?: number;
     http?: HttpOptions;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,27 +1,53 @@
 /// <reference types="node" />
 import * as fastify from "fastify";
-import { IncomingMessage, IncomingHttpHeaders } from "http";
+import {
+  IncomingMessage,
+  IncomingHttpHeaders,
+  RequestOptions,
+  AgentOptions,
+} from "http";
+import {
+  RequestOptions as SecureRequestOptions,
+  AgentOptions as SecureAgentOptions,
+} from "https";
 import {
   Http2ServerRequest,
-  IncomingHttpHeaders as Http2IncomingHttpHeaders
+  IncomingHttpHeaders as Http2IncomingHttpHeaders,
+  ClientSessionRequestOptions,
+  ClientSessionOptions,
+  SecureClientSessionOptions,
 } from "http2";
 
 declare function fastifyReplyFrom<HttpServer, HttpRequest, HttpResponse>(
   instance: fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>,
-  opts: fastifyReplyFrom.ReplyFromOptions,
+  opts?: fastifyReplyFrom.ReplyFromOptions,
   callback?: (err?: Error) => void
 ): void;
 
+interface Http2Options {
+  sessionTimeout?: number;
+  requestTimeout?: number;
+  sessionOptions?: ClientSessionOptions | SecureClientSessionOptions;
+  requestOptions?: ClientSessionRequestOptions;
+}
+
+interface HttpOptions {
+  agentOptions?: AgentOptions | SecureAgentOptions;
+  requestOptions?: RequestOptions | SecureRequestOptions;
+}
+
 declare namespace fastifyReplyFrom {
   interface ReplyFromOptions {
-    base: string;
+    base?: string;
     cacheURLs?: number;
-    http2?: boolean;
+    http?: HttpOptions;
+    http2?: Http2Options | boolean;
+    undici?: unknown; // undici has no TS declarations yet
     keepAliveMsecs?: number;
     maxFreeSockets?: number;
     maxSockets?: number;
     rejectUnauthorized?: boolean;
-    undici?: unknown;
+    sessionTimeout?: number;
   }
 }
 
@@ -42,13 +68,13 @@ declare module "fastify" {
 
         body?: unknown;
         rewriteHeaders?: (
-          headers: Http2IncomingHttpHeaders
-        ) => Http2IncomingHttpHeaders;
+          headers: Http2IncomingHttpHeaders | IncomingHttpHeaders
+        ) => Http2IncomingHttpHeaders | IncomingHttpHeaders;
 
         rewriteRequestHeaders?: (
           req: Http2ServerRequest | IncomingMessage,
-          headers: Http2IncomingHttpHeaders
-        ) => Http2IncomingHttpHeaders;
+          headers: Http2IncomingHttpHeaders | IncomingHttpHeaders
+        ) => Http2IncomingHttpHeaders | IncomingHttpHeaders;
       }
     ): void;
   }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const {
   stripHttp1ConnectionHeaders
 } = require('./lib/utils')
 
-const { ERR_TIMED_OUT_CODE } = buildRequest
+const { TimeoutError } = buildRequest
 
 module.exports = fp(function from (fastify, opts, next) {
   const cache = lru(opts.cacheURLs || 100)
@@ -105,7 +105,7 @@ module.exports = fp(function from (fastify, opts, next) {
         if (!this.sent) {
           if (err.code === 'ERR_HTTP2_STREAM_CANCEL') {
             this.code(503).send(new Error('Service Unavailable'))
-          } else if (err.code === ERR_TIMED_OUT_CODE) {
+          } else if (err instanceof TimeoutError) {
             this.code(504).send('Gateway Timeout')
           } else {
             this.send(err)

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ module.exports = fp(function from (fastify, opts, next) {
           if (err.code === 'ERR_HTTP2_STREAM_CANCEL') {
             this.code(503).send(new Error('Service Unavailable'))
           } else if (err instanceof TimeoutError) {
-            this.code(504).send('Gateway Timeout')
+            this.code(504).send(new Error('Gateway Timeout'))
           } else {
             this.send(err)
           }

--- a/lib/request.js
+++ b/lib/request.js
@@ -7,6 +7,8 @@ const pump = require('pump')
 const undici = require('undici')
 const { stripHttp1ConnectionHeaders } = require('./utils')
 
+const ERR_TIMED_OUT_CODE = 'ETIMEDOUT'
+
 function buildRequest (opts) {
   const isHttp2 = !!opts.http2
   const isUndici = !!opts.undici
@@ -15,8 +17,8 @@ function buildRequest (opts) {
     'https:': https
   }
   const baseUrl = opts.base
-  const rejectUnauthorized = opts.rejectUnauthorized
-  const sessionTimeout = opts.sessionTimeout || 60000
+  const http2Opts = getHttp2Opts(opts)
+  const httpOpts = getHttpOpts(opts)
   var http2Client
   var pool
   var agents
@@ -29,8 +31,8 @@ function buildRequest (opts) {
     if (!opts.base) throw new Error('Option base is required when http2 is true')
   } else {
     agents = {
-      'http:': new http.Agent(agentOption(opts)),
-      'https:': new https.Agent(agentOption(opts))
+      'http:': new http.Agent(httpOpts.agentOptions),
+      'https:': new https.Agent(httpOpts.agentOptions)
     }
   }
 
@@ -65,11 +67,18 @@ function buildRequest (opts) {
       path: opts.url.pathname + opts.qs,
       hostname: opts.url.hostname,
       headers: opts.headers,
-      agent: agents[opts.url.protocol]
+      agent: agents[opts.url.protocol],
+      ...httpOpts.requestOptions
     })
     req.on('error', done)
     req.on('response', res => {
       done(null, { statusCode: res.statusCode, headers: res.headers, stream: res })
+    })
+    req.once('timeout', () => {
+      const err = new Error('HTTP request timed out')
+      err.code = ERR_TIMED_OUT_CODE
+      req.abort()
+      done(err)
     })
     end(req, opts.body, done)
   }
@@ -92,13 +101,21 @@ function buildRequest (opts) {
   }
 
   function handleHttp2Req (opts, done) {
+    let cancelRequest
+    let sessionTimedOut = false
+
     if (!http2Client || http2Client.destroyed) {
-      http2Client = http2.connect(baseUrl, { rejectUnauthorized })
+      http2Client = http2.connect(baseUrl, http2Opts.sessionOptions)
       http2Client.once('error', done)
       // we might enqueue a large number of requests in this connection
       // before it's connected
       http2Client.setMaxListeners(0)
-      http2Client.setTimeout(sessionTimeout, function () {
+      http2Client.setTimeout(http2Opts.sessionTimeout, function () {
+        if (cancelRequest) {
+          cancelRequest()
+          cancelRequest = undefined
+          sessionTimedOut = true
+        }
         http2Client.destroy()
       })
       http2Client.once('connect', () => {
@@ -111,12 +128,25 @@ function buildRequest (opts) {
       ':method': opts.method,
       ':path': opts.url.pathname + opts.qs,
       ...stripHttp1ConnectionHeaders(opts.headers)
-    })
+    }, http2Opts.requestOptions)
     const isGet = opts.method === 'GET' || opts.method === 'get'
     if (!isGet) {
       end(req, opts.body, done)
     }
-    eos(req, err => {
+    req.setTimeout(http2Opts.requestTimeout, () => {
+      const err = new Error('HTTP/2 request timed out')
+      err.code = ERR_TIMED_OUT_CODE
+      req.close(http2.constants.NGHTTP2_CANCEL)
+      done(err)
+    })
+    req.once('close', () => {
+      if (sessionTimedOut) {
+        const err = new Error('HTTP/2 session timed out')
+        err.code = ERR_TIMED_OUT_CODE
+        done(err)
+      }
+    })
+    cancelRequest = eos(req, err => {
       if (err) done(err)
     })
     req.on('response', headers => {
@@ -127,16 +157,7 @@ function buildRequest (opts) {
 }
 
 module.exports = buildRequest
-
-function agentOption (opts) {
-  return {
-    keepAlive: true,
-    keepAliveMsecs: opts.keepAliveMsecs || 60 * 1000, // 1 minute
-    maxSockets: opts.maxSockets || 2048,
-    maxFreeSockets: opts.maxFreeSockets || 2048,
-    rejectUnauthorized: opts.rejectUnauthorized
-  }
-}
+module.exports.ERR_TIMED_OUT_CODE = ERR_TIMED_OUT_CODE
 
 function end (req, body, cb) {
   if (!body || typeof body === 'string' || body instanceof Uint8Array) {
@@ -153,4 +174,54 @@ function end (req, body, cb) {
 // neede to avoid the experimental warning
 function getHttp2 () {
   return require('http2')
+}
+
+function getHttp2Opts (opts) {
+  if (!opts.http2) {
+    return {}
+  }
+
+  let http2Opts = opts.http2
+  if (typeof http2Opts === 'boolean') {
+    http2Opts = {}
+  }
+  http2Opts.sessionOptions = http2Opts.sessionOptions || {}
+
+  if (!http2Opts.sessionTimeout) {
+    http2Opts.sessionTimeout = opts.sessionTimeout || 6000
+  }
+  if (!http2Opts.requestTimeout) {
+    http2Opts.requestTimeout = 10000
+  }
+  if (!opts.rejectUnauthorized) {
+    http2Opts.sessionOptions.rejectUnauthorized = false
+  }
+
+  return http2Opts
+}
+
+function getHttpOpts (opts) {
+  const httpOpts = opts.http || {}
+  httpOpts.requestOptions = httpOpts.requestOptions || {}
+
+  if (!httpOpts.requestOptions.timeout) {
+    httpOpts.requestOptions.timeout = 10000
+  }
+  if (!opts.rejectUnauthorized) {
+    httpOpts.requestOptions.rejectUnauthorized = false
+  }
+
+  httpOpts.agentOptions = getAgentOptions(opts)
+
+  return httpOpts
+}
+
+function getAgentOptions (opts) {
+  return {
+    keepAlive: true,
+    keepAliveMsecs: opts.keepAliveMsecs || 60 * 1000, // 1 minute
+    maxSockets: opts.maxSockets || 2048,
+    maxFreeSockets: opts.maxFreeSockets || 2048,
+    ...(opts.http && opts.http.agentOptions)
+  }
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -7,7 +7,7 @@ const pump = require('pump')
 const undici = require('undici')
 const { stripHttp1ConnectionHeaders } = require('./utils')
 
-const ERR_TIMED_OUT_CODE = 'ETIMEDOUT'
+class TimeoutError extends Error {}
 
 function buildRequest (opts) {
   const isHttp2 = !!opts.http2
@@ -75,8 +75,7 @@ function buildRequest (opts) {
       done(null, { statusCode: res.statusCode, headers: res.headers, stream: res })
     })
     req.once('timeout', () => {
-      const err = new Error('HTTP request timed out')
-      err.code = ERR_TIMED_OUT_CODE
+      const err = new TimeoutError('HTTP request timed out')
       req.abort()
       done(err)
     })
@@ -134,15 +133,13 @@ function buildRequest (opts) {
       end(req, opts.body, done)
     }
     req.setTimeout(http2Opts.requestTimeout, () => {
-      const err = new Error('HTTP/2 request timed out')
-      err.code = ERR_TIMED_OUT_CODE
+      const err = new TimeoutError('HTTP/2 request timed out')
       req.close(http2.constants.NGHTTP2_CANCEL)
       done(err)
     })
     req.once('close', () => {
       if (sessionTimedOut) {
-        const err = new Error('HTTP/2 session timed out')
-        err.code = ERR_TIMED_OUT_CODE
+        const err = new TimeoutError('HTTP/2 session timed out')
         done(err)
       }
     })
@@ -157,7 +154,7 @@ function buildRequest (opts) {
 }
 
 module.exports = buildRequest
-module.exports.ERR_TIMED_OUT_CODE = ERR_TIMED_OUT_CODE
+module.exports.TimeoutError = TimeoutError
 
 function end (req, body, cb) {
   if (!body || typeof body === 'string' || body instanceof Uint8Array) {

--- a/test/http-timeout.js
+++ b/test/http-timeout.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const got = require('got')
+
+t.autoend(false)
+
+const target = Fastify()
+t.tearDown(target.close.bind(target))
+
+target.get('/', (request, reply) => {
+  t.pass('request arrives')
+
+  setTimeout(() => {
+    reply.status(200).send('hello world')
+    t.end()
+  }, 1000)
+})
+
+async function main () {
+  await target.listen(0)
+
+  const instance = Fastify()
+  t.tearDown(instance.close.bind(instance))
+
+  instance.register(From, { http: { requestOptions: { timeout: 100 } } })
+
+  instance.get('/', (request, reply) => {
+    reply.from(`http://localhost:${target.server.address().port}/`)
+  })
+
+  await instance.listen(0)
+
+  try {
+    await got.get(`http://localhost:${instance.server.address().port}/`, { retry: 0 })
+  } catch (err) {
+    t.equal(err.response.statusCode, 504)
+    t.equal(err.response.body, 'Gateway Timeout')
+
+    return
+  }
+
+  t.fail()
+}
+
+main()

--- a/test/http-timeout.js
+++ b/test/http-timeout.js
@@ -37,7 +37,12 @@ async function main () {
     await got.get(`http://localhost:${instance.server.address().port}/`, { retry: 0 })
   } catch (err) {
     t.equal(err.response.statusCode, 504)
-    t.equal(err.response.body, 'Gateway Timeout')
+    t.match(err.response.headers['content-type'], /application\/json/)
+    t.deepEqual(JSON.parse(err.response.body), {
+      statusCode: 504,
+      error: 'Gateway Timeout',
+      message: 'Gateway Timeout'
+    })
 
     return
   }

--- a/test/http2-timeout.js
+++ b/test/http2-timeout.js
@@ -35,7 +35,12 @@ test('http2 request timeout', async (t) => {
     })
   } catch (err) {
     t.equal(err.response.statusCode, 504)
-    t.equal(err.response.body, 'Gateway Timeout')
+    t.match(err.response.headers['content-type'], /application\/json/)
+    t.deepEqual(JSON.parse(err.response.body), {
+      statusCode: 504,
+      error: 'Gateway Timeout',
+      message: 'Gateway Timeout'
+    })
 
     return
   }
@@ -73,7 +78,12 @@ test('http2 session timeout', async (t) => {
     })
   } catch (err) {
     t.equal(err.response.statusCode, 504)
-    t.equal(err.response.body, 'Gateway Timeout')
+    t.match(err.response.headers['content-type'], /application\/json/)
+    t.deepEqual(JSON.parse(err.response.body), {
+      statusCode: 504,
+      error: 'Gateway Timeout',
+      message: 'Gateway Timeout'
+    })
 
     return
   }

--- a/test/http2-timeout.js
+++ b/test/http2-timeout.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const got = require('got')
+
+test('http2 request timeout', async (t) => {
+  const target = Fastify({ http2: true, sessionTimeout: 0 })
+  t.tearDown(target.close.bind(target))
+
+  target.get('/', () => {
+    t.pass('request arrives')
+  })
+
+  await target.listen(0)
+
+  const instance = Fastify()
+  t.tearDown(instance.close.bind(instance))
+
+  instance.register(From, {
+    base: `http://localhost:${target.server.address().port}`,
+    http2: { requestTimeout: 100 }
+  })
+
+  instance.get('/', (request, reply) => {
+    reply.from(`http://localhost:${target.server.address().port}/`)
+  })
+
+  await instance.listen(0)
+
+  try {
+    await got.get(`http://localhost:${instance.server.address().port}/`, {
+      retry: 0
+    })
+  } catch (err) {
+    t.equal(err.response.statusCode, 504)
+    t.equal(err.response.body, 'Gateway Timeout')
+
+    return
+  }
+
+  t.fail()
+})
+
+test('http2 session timeout', async (t) => {
+  const target = Fastify({ http2: true, sessionTimeout: 0 })
+  t.tearDown(target.close.bind(target))
+
+  target.get('/', () => {
+    t.pass('request arrives')
+  })
+
+  await target.listen(0)
+
+  const instance = Fastify()
+  t.tearDown(instance.close.bind(instance))
+
+  instance.register(From, {
+    base: `http://localhost:${target.server.address().port}`,
+    http2: { sessionTimeout: 100 }
+  })
+
+  instance.get('/', (request, reply) => {
+    reply.from(`http://localhost:${target.server.address().port}/`)
+  })
+
+  await instance.listen(0)
+
+  try {
+    await got.get(`http://localhost:${instance.server.address().port}/`, {
+      retry: 0
+    })
+  } catch (err) {
+    t.equal(err.response.statusCode, 504)
+    t.equal(err.response.body, 'Gateway Timeout')
+
+    return
+  }
+
+  t.fail()
+})

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -2,10 +2,30 @@ import replyFrom, { ReplyFromOptions } from "../";
 import fastify from "fastify";
 import { AddressInfo } from "net";
 import { IncomingHttpHeaders } from "http2";
+import { Server, IncomingMessage, ServerResponse } from "http";
 
-const fullOptions: ReplyFromOptions = {
+const fullOptions: ReplyFromOptions<Server, IncomingMessage, ServerResponse> = {
   base: "http://example2.com",
-  http2: true,
+  http: {
+    agentOptions: {
+      keepAliveMsecs: 60 * 1000,
+      maxFreeSockets: 2048,
+      maxSockets: 2048
+    },
+    requestOptions: {
+      timeout: 1000
+    }
+  },
+  http2: {
+    sessionTimeout: 1000,
+    requestTimeout: 1000,
+    sessionOptions: {
+      rejectUnauthorized: true
+    },
+    requestOptions: {
+      endStream: true
+    }
+  },
   cacheURLs: 100,
   keepAliveMsecs: 60 * 1000,
   maxFreeSockets: 2048,
@@ -19,9 +39,11 @@ const fullOptions: ReplyFromOptions = {
 
 const server = fastify();
 
-server.register(replyFrom, {
-  base: "http://example.com"
-});
+server.register(replyFrom);
+
+server.register(replyFrom, {});
+
+server.register(replyFrom, { http2: true });
 
 server.register(replyFrom, fullOptions);
 


### PR DESCRIPTION
Addresses #68 

The general idea follows the discussion from the issue: introduce `http` & `http2` options, along with timeouts handling.

The new API:

```js
fastify.register(require('fastify-reply-from'), {
  http: {
    agentOptions: { // supports all options from https://nodejs.org/api/https.html#https_new_agent_options
      keepAliveMsecs: 30000, // supersedes options.keepAliveMsecs
      maxFreeSockets: 100, // supersedes options.maxFreeSockets
      maxSockets: 200 // supersedes options.maxSockets
    },
    requestOptions : { // supports all options from https://nodejs.org/api/https.html#https_https_request_url_options_callback
      timeout: 5000, // has default of 10000, with attached timeout callback
      rejectUnauthorized: true // supersedes options.rejectUnauthorized, defaults to false (Node defaults to true)
    }
  },
  http2: {
    sessionTimeout: 30000, // supersedes options.sessionTimeout, now with attached timeout callback
    requestTimeout: 5000, // has default of 10000, with attached timeout callback
    sessionOptions: { // supports all options from https://nodejs.org/api/http2.html#http2_http2_connect_authority_options_listener
       rejectUnauthorized: true // supersedes options.rejectUnauthorized, defaults to false (Node defaults to true)
    },
    requestOptions : { // supports all options from https://nodejs.org/api/http2.html#http2_clienthttp2session_request_headers_options
      endStream: true // just some random request.options as an illustration :)
    }
  }
}
```

Would love to get some feedbacks before continuing with the rest of TODOs.

TODO:
- [X] update docs (new readme is accessible at https://github.com/felixputera/fastify-reply-from for rich preview)
- [X] TS declarations tests

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
