### PR TITLE
Handle ENOTFOUND error, set default error code to 500 rather than 200

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,12 +103,12 @@ module.exports = fp(function from (fastify, opts, next) {
       if (err) {
         this.request.log.warn(err, 'response errored')
         if (!this.sent) {
-          if (err.code === 'ERR_HTTP2_STREAM_CANCEL') {
+          if (err.code === 'ERR_HTTP2_STREAM_CANCEL' || err.code === 'ENOTFOUND') {
             this.code(503).send(new Error('Service Unavailable'))
           } else if (err instanceof TimeoutError) {
             this.code(504).send(new Error('Gateway Timeout'))
           } else {
-            this.send(err)
+            this.code(500).send(err)
           }
         }
         return

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "msgpack5": "^4.2.1",
     "nock": "^13.0.0",
     "pre-commit": "^1.2.2",
-    "proxyquire": "^2.1.0",
+    "proxyquire": "^2.1.3",
     "simple-get": "^4.0.0",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3",

--- a/test/http-invalid-target.js
+++ b/test/http-invalid-target.js
@@ -5,7 +5,7 @@ const Fastify = require('fastify')
 const From = require('..')
 const got = require('got')
 
-test('http -> http2', async (t) => {
+test('http invalid target', async (t) => {
   const instance = Fastify()
 
   t.tearDown(instance.close.bind(instance))

--- a/test/http-invalid-target.js
+++ b/test/http-invalid-target.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const got = require('got')
+
+test('http -> http2', async (t) => {
+  const instance = Fastify()
+
+  t.tearDown(instance.close.bind(instance))
+
+  instance.get('/', (request, reply) => {
+    reply.from()
+  })
+  instance.register(From, {
+    base: 'http://abc.xyz1'
+  })
+
+  await instance.listen(0)
+
+  try {
+    await got(`http://localhost:${instance.server.address().port}`)
+  } catch (err) {
+    t.equal(err.response.statusCode, 503)
+    t.match(err.response.headers['content-type'], /application\/json/)
+    t.deepEqual(JSON.parse(err.response.body), {
+      statusCode: 503,
+      error: 'Service Unavailable',
+      message: 'Service Unavailable'
+    })
+    return
+  }
+  t.fail()
+})

--- a/test/http2-invalid-target.js
+++ b/test/http2-invalid-target.js
@@ -5,7 +5,7 @@ const Fastify = require('fastify')
 const From = require('..')
 const got = require('got')
 
-test('http -> http2', async (t) => {
+test('http2 invalid target', async (t) => {
   const instance = Fastify()
 
   t.tearDown(instance.close.bind(instance))

--- a/test/unexpected-error.js
+++ b/test/unexpected-error.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const got = require('got')
+const proxyquire = require('proxyquire')
+
+// Stub request to throw error 'foo'
+const From = proxyquire('..', {
+  './lib/request': function () {
+    return {
+      request: (opts, callback) => { callback(new Error('foo')) },
+      close: () => {}
+    }
+  }
+})
+
+test('unexpected error renders 500', async (t) => {
+  const instance = Fastify()
+
+  t.tearDown(instance.close.bind(instance))
+
+  instance.get('/', (request, reply) => {
+    reply.code(201)
+    reply.from()
+  })
+  instance.register(From, {
+    base: 'http://localhost'
+  })
+
+  await instance.listen(0)
+
+  try {
+    await got(`http://localhost:${instance.server.address().port}`)
+  } catch (err) {
+    t.equal(err.response.statusCode, 500)
+    t.match(err.response.headers['content-type'], /application\/json/)
+    t.deepEqual(JSON.parse(err.response.body), {
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'foo'
+    })
+    return
+  }
+  t.fail()
+})


### PR DESCRIPTION
Hi there.  Small change to add error handling for failed DNS lookup when using http 1.  There was an existing test for http 2 only.  Also changes the default error code when an unknown error occurs to 500 rather than 200.