### PR TITLE
Support for UND_ERR_REQUEST_TIMEOUT

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ module.exports = fp(function from (fastify, opts, next) {
         if (!this.sent) {
           if (err.code === 'ERR_HTTP2_STREAM_CANCEL' || err.code === 'ENOTFOUND') {
             this.code(503).send(new Error('Service Unavailable'))
-          } else if (err instanceof TimeoutError) {
+          } else if (err instanceof TimeoutError || err.code === 'UND_ERR_REQUEST_TIMEOUT') {
             this.code(504).send(new Error('Gateway Timeout'))
           } else {
             this.code(500).send(err)

--- a/test/undici-timeout.js
+++ b/test/undici-timeout.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const got = require('got')
+
+t.autoend(false)
+
+const target = Fastify()
+t.tearDown(target.close.bind(target))
+
+target.get('/', (request, reply) => {
+  t.pass('request arrives')
+
+  setTimeout(() => {
+    reply.status(200).send('hello world')
+    t.end()
+  }, 1000)
+})
+
+async function main () {
+  await target.listen(0)
+
+  const instance = Fastify()
+  t.tearDown(instance.close.bind(instance))
+
+  instance.register(From, {
+    base: `http://localhost:${target.server.address().port}`,
+    undici: {
+      requestTimeout: 100
+    }
+  })
+
+  instance.get('/', (request, reply) => {
+    reply.from()
+  })
+
+  await instance.listen(0)
+
+  try {
+    await got.get(`http://localhost:${instance.server.address().port}/`, { retry: 0 })
+  } catch (err) {
+    t.equal(err.response.statusCode, 504)
+    t.match(err.response.headers['content-type'], /application\/json/)
+    t.deepEqual(JSON.parse(err.response.body), {
+      statusCode: 504,
+      error: 'Gateway Timeout',
+      message: 'Gateway Timeout'
+    })
+
+    return
+  }
+
+  t.fail()
+}
+
+main()


### PR DESCRIPTION


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
