### PR TITLE
issue-108: Add an option to provide custom http/s agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ proxy.register(require('fastify-reply-from'), {
 })
 ```
 
+You can also pass a custom http agents. If you pass the agents, then the http.agentOptions will be ignored. To illustrate:
+```js
+proxy.register(require('fastify-reply-from'), {
+  base: 'http://localhost:3001/',
+  http: {
+    agents: { 
+      'http:': new http.Agent({ keepAliveMsecs: 10 * 60 * 1000 }), // pass in any options from https://nodejs.org/api/http.html#http_new_agent_options
+      'https:': new https.Agent({ keepAliveMsecs: 10 * 60 * 1000 })
+               
+    },
+    requestOptions: { // pass in any options from https://nodejs.org/api/http.html#http_http_request_options_callback
+      timeout: 5000 // timeout in msecs, defaults to 10000 (10 seconds)
+    }
+  }
+})
+```
 #### `http2`
 You can either set `http2` to `true` or set the settings object to connect to a HTTP/2 server.
 The `http2` settings object has the shape of:

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,10 +14,12 @@ import {
   IncomingHttpHeaders,
   RequestOptions,
   AgentOptions,
+  Agent,
 } from "http";
 import {
   RequestOptions as SecureRequestOptions,
   AgentOptions as SecureAgentOptions,
+  Agent as SecureAgent
 } from "https";
 import {
   Http2ServerRequest,
@@ -68,6 +70,7 @@ interface Http2Options {
 interface HttpOptions {
   agentOptions?: AgentOptions | SecureAgentOptions;
   requestOptions?: RequestOptions | SecureRequestOptions;
+  agents?: { 'http:': Agent, 'https:': SecureAgent }
 }
 
 export interface FastifyReplyFromOptions {

--- a/lib/request.js
+++ b/lib/request.js
@@ -37,7 +37,8 @@ function buildRequest (opts) {
       throw new Error('Unix socket destination is not supported when http2 is true')
     }
   } else {
-    agents = {
+    const httpOpts = opts.http || {}
+    agents = httpOpts.agents || {
       'http:': new http.Agent(httpOpts.agentOptions),
       'https:': new https.Agent(httpOpts.agentOptions)
     }

--- a/lib/request.js
+++ b/lib/request.js
@@ -37,7 +37,6 @@ function buildRequest (opts) {
       throw new Error('Unix socket destination is not supported when http2 is true')
     }
   } else {
-    const httpOpts = opts.http || {}
     agents = httpOpts.agents || {
       'http:': new http.Agent(httpOpts.agentOptions),
       'https:': new https.Agent(httpOpts.agentOptions)

--- a/test/http-agents.js
+++ b/test/http-agents.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const https = require('https')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+
+t.plan(10)
+t.tearDown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/', (request, reply) => {
+  reply.from()
+})
+
+t.tearDown(target.close.bind(target))
+
+target.listen(0, (err) => {
+  t.error(err)
+
+  instance.register(From, {
+    base: `http://localhost:${target.address().port}`,
+    http: {
+      agents: {
+        'http:': new http.Agent({}),
+        'https:': new https.Agent({})
+      }
+    }
+  })
+
+  instance.listen(0, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})

--- a/test/https-agents.js
+++ b/test/https-agents.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const https = require('https')
+const get = require('simple-get').concat
+
+const fs = require('fs')
+const path = require('path')
+const certs = {
+  key: fs.readFileSync(path.join(__dirname, 'fixtures', 'fastify.key')),
+  cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'fastify.cert'))
+}
+
+const instance = Fastify({
+  https: certs
+})
+
+t.plan(10)
+t.tearDown(instance.close.bind(instance))
+
+const target = https.createServer(certs, (req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/', (request, reply) => {
+  reply.from()
+})
+
+t.tearDown(target.close.bind(target))
+
+target.listen(0, (err) => {
+  t.error(err)
+
+  instance.register(From, {
+    base: `https://localhost:${target.address().port}`,
+    http: {
+      agents: {
+        'http:': new http.Agent({}),
+        'https:': new https.Agent({})
+      }
+    }
+  })
+
+  instance.listen(0, (err) => {
+    t.error(err)
+
+    get({
+      url: `https://localhost:${instance.server.address().port}`,
+      rejectUnauthorized: false
+    }, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -4,6 +4,7 @@ import { AddressInfo } from "net";
 import { IncomingHttpHeaders } from "http2";
 import { expectType } from 'tsd';
 import * as http from 'http';
+import * as https from 'https';
 import * as http2 from 'http2';
 // @ts-ignore
 import tap from 'tap'
@@ -18,6 +19,10 @@ const fullOptions: FastifyReplyFromOptions = {
     },
     requestOptions: {
       timeout: 1000
+    },
+    agents: {
+      'http:': new http.Agent({}),
+      'https:': new https.Agent({})
     }
   },
   http2: {


### PR DESCRIPTION
Issue:
https://github.com/fastify/fastify-reply-from/issues/108 Add an option to provide custom http/s agent
#### Checklist

- [ v] run `npm run test` and `npm run benchmark`
- [ v ] tests and/or benchmarks are included
- [ v ] documentation is changed or added
- [ v ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
