### PR TITLE
Fixes a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Note that _every path will be discarded_.
 
 Custom URL protocols `unix+http:` and `unix+https:` can be used to forward requests to a unix
 socket server by using `querystring.escape(socketPath)` as the hostname.  This is not supported
-for http2 nor unidici.  To illustrate:
+for http2 nor undici.  To illustrate:
 
 ```js
 const socketPath = require('querystring').escape('/run/http-daemon.socket')


### PR DESCRIPTION
Changes unidici to undici in the README.


#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
