### PR TITLE
fix: add port to host header if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = fp(function from (fastify, opts, next) {
 
     const sourceHttp2 = req.httpVersionMajor === 2
     const headers = sourceHttp2 ? filterPseudoHeaders(req.headers) : req.headers
-    headers.host = url.hostname
+    headers.host = url.host
     const qs = getQueryString(url.search, req.url, opts)
     let body = ''
 

--- a/test/host-header.js
+++ b/test/host-header.js
@@ -1,38 +1,65 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('tap')
 const Fastify = require('fastify')
 const From = require('..')
-const get = require('simple-get').concat
 const nock = require('nock')
+const got = require('got')
 
-const instance = Fastify()
+test('hostname', async (t) => {
+  const instance = Fastify()
+  t.tearDown(instance.close.bind(instance))
 
-nock('http://httpbin.org')
-  .get('/ip')
-  .reply(200, function (uri, requestBody) {
-    t.is(this.req.headers.host, 'httpbin.org')
-    return { origin: '127.0.0.1' }
+  nock('http://httpbin.org')
+    .get('/ip')
+    .reply(200, function (uri, requestBody) {
+      t.is(this.req.headers.host, 'httpbin.org')
+      return { origin: '127.0.0.1' }
+    })
+
+  instance.get('*', (request, reply) => {
+    reply.from()
   })
 
-t.plan(6)
-t.tearDown(instance.close.bind(instance))
-
-instance.get('*', (request, reply) => {
-  reply.from()
-})
-
-instance.register(From, {
-  base: 'http://httpbin.org'
-})
-
-instance.listen(0, (err) => {
-  t.error(err)
-
-  get(`http://localhost:${instance.server.address().port}/ip`, (err, res, data) => {
-    t.error(err)
-    t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-type'], 'application/json')
-    t.strictEqual(typeof JSON.parse(data).origin, 'string')
+  instance.register(From, {
+    base: 'http://httpbin.org'
   })
+
+  await instance.listen(0)
+
+  const res = await got.get(`http://localhost:${instance.server.address().port}/ip`, {
+    retry: 0
+  })
+  t.strictEqual(res.statusCode, 200)
+  t.strictEqual(res.headers['content-type'], 'application/json')
+  t.strictEqual(typeof JSON.parse(res.body).origin, 'string')
+})
+
+test('hostname and port', async (t) => {
+  const instance = Fastify()
+  t.tearDown(instance.close.bind(instance))
+
+  nock('http://httpbin.org:8080')
+    .get('/ip')
+    .reply(200, function (uri, requestBody) {
+      t.is(this.req.headers.host, 'httpbin.org:8080')
+      return { origin: '127.0.0.1' }
+    })
+
+  instance.get('*', (request, reply) => {
+    reply.from()
+  })
+
+  instance.register(From, {
+    base: 'http://httpbin.org:8080'
+  })
+
+  await instance.listen(0)
+
+  const res = await got.get(`http://localhost:${instance.server.address().port}/ip`, {
+    retry: 0
+  })
+  t.strictEqual(res.statusCode, 200)
+  t.strictEqual(res.headers['content-type'], 'application/json')
+  t.strictEqual(typeof JSON.parse(res.body).origin, 'string')
 })


### PR DESCRIPTION
Fixes #144 

#### Checklist

- [x] run `npm run test` and ~`npm run benchmark`~
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
