### PR TITLE
fix: send correct error message when rewriting body fails (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ This will be passed to
 Replaces the original request body with what is specified. Unless
 [`contentType`][contentType] is specified, the content will be passed
 through `JSON.stringify()`.
-Setting this option will not verify if the http method allows for a body.
+Setting this option for GET, HEAD requests will throw an error "Rewriting the body when doing a {GET|HEAD} is not allowed".
+
 
 #### `contentType`
 

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ module.exports = fp(function from (fastify, opts, next) {
       // if we are doing that with a GET or HEAD request is a programmer error
       // and as such we can throw immediately.
       if (body) {
-        throw new Error('Rewriting the body when doing a GET is not allowed')
+        throw new Error(`Rewriting the body when doing a ${req.method} is not allowed`)
       }
     }
 

--- a/test/no-body-opts-with-head.js
+++ b/test/no-body-opts-with-head.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+
+t.plan(7)
+t.tearDown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.fail('this should never get called')
+  res.end('hello world')
+})
+
+instance.head('/', (request, reply) => {
+  try {
+    reply.from(null, { body: 'this is the new body' })
+  } catch (e) {
+    t.strictEqual(e.message, 'Rewriting the body when doing a HEAD is not allowed')
+    reply.header('x-http-error', '1')
+    reply.send('hello world')
+  }
+})
+
+t.tearDown(target.close.bind(target))
+
+target.listen(0, (err) => {
+  t.error(err)
+
+  instance.register(From, {
+    base: `http://localhost:${target.address().port}`
+  })
+
+  instance.listen(0, (err) => {
+    t.error(err)
+
+    get({
+      url: `http://localhost:${instance.server.address().port}`,
+      method: 'HEAD'
+    }, (err, res, data) => {
+      t.error(err)
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers['x-http-error'], '1')
+      t.equal(data.toString(), '')
+    })
+  })
+})


### PR DESCRIPTION
**Changes:**
- updated docs
- changed error message to respect HTTP method
- added tests for no options.body, HEAD method

#### Checklist

- [x] run `npm run test`
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
