### PR TITLE
fix: encoding when used with fastify-formbody plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ This will be passed to
 #### `body`
 
 Replaces the original request body with what is specified. Unless
-[`contentType`][contentType] is specified, the content will be passed
+[`contentType`](#contentType) is specified, the content will be passed
 through `JSON.stringify()`.
 Setting this option for GET, HEAD requests will throw an error "Rewriting the body when doing a {GET|HEAD} is not allowed".
 
@@ -248,7 +248,25 @@ Setting this option for GET, HEAD requests will throw an error "Rewriting the bo
 #### `contentType`
 
 Override the `'Content-Type'` header of the forwarded request, if we are
-already overriding the [`body`][body].
+already overriding the [`body`](#body).
+
+#### `contentTypesToEncode`
+
+An array of content types whose response body will be passed through `JSON.stringify()`. 
+This only applies when a custom [`body`](#body) is not passed in. Defaults to:
+
+```js
+[ 
+  'application/json',
+  'application/x-www-form-urlencoded'
+]
+```
+
+### Combining with [fastify-formbody](https://github.com/fastify/fastify-formbody)
+
+`formbody` expects the body to be returned as a string and not an object. 
+Use the [`contentTypesToEncode`](#contentTypesToEncode) option to pass in `['application/x-www-form-urlencoded']`
+
 
 ### HTTP & HTTP2 timeouts
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,18 @@ This option will disable the URL caching.
 This cache is dedicated to reduce the amount of URL object generation.
 Generating URLs is a main bottleneck of this module, please disable this cache with caution.
 
+#### `contentTypesToEncode`
+
+An array of content types whose response body will be passed through `JSON.stringify()`. 
+This only applies when a custom [`body`](#body) is not passed in. Defaults to:
+
+```js
+[ 
+  'application/json',
+  'application/x-www-form-urlencoded'
+]
+```
+
 ---
 
 ### `reply.from(source, [opts])`
@@ -249,18 +261,6 @@ Setting this option for GET, HEAD requests will throw an error "Rewriting the bo
 
 Override the `'Content-Type'` header of the forwarded request, if we are
 already overriding the [`body`](#body).
-
-#### `contentTypesToEncode`
-
-An array of content types whose response body will be passed through `JSON.stringify()`. 
-This only applies when a custom [`body`](#body) is not passed in. Defaults to:
-
-```js
-[ 
-  'application/json',
-  'application/x-www-form-urlencoded'
-]
-```
 
 ### Combining with [fastify-formbody](https://github.com/fastify/fastify-formbody)
 

--- a/index.js
+++ b/index.js
@@ -32,10 +32,6 @@ module.exports = fp(function from (fastify, opts, next) {
     const rewriteRequestHeaders = opts.rewriteRequestHeaders || requestHeadersNoOp
     const getUpstream = opts.getUpstream || upstreamNoOp
     const onError = opts.onError || onErrorDefault
-    const contentTypesToEncode = new Set([
-      'application/json',
-      ...(opts.contentTypesToEncode || [])
-    ])
 
     if (!source) {
       source = req.url
@@ -80,6 +76,10 @@ module.exports = fp(function from (fastify, opts, next) {
         // detect if body should be encoded as JSON
         // supporting extended content-type header formats:
         // - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+        const contentTypesToEncode = new Set([
+          'application/json',
+          ...(opts.contentTypesToEncode || [])
+        ])
         const lowerCaseContentType = contentType.toLowerCase()
         const plainContentType = lowerCaseContentType.indexOf(';') > -1
           ? lowerCaseContentType.slice(0, lowerCaseContentType.indexOf(';'))

--- a/index.js
+++ b/index.js
@@ -76,7 +76,13 @@ module.exports = fp(function from (fastify, opts, next) {
         // detect if body should be encoded as JSON
         // supporting extended content-type header formats:
         // - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
-        const shouldEncodeJSON = contentType.toLowerCase().indexOf('application/json') === 0
+        const contentTypesNotToEncode = [
+          'application/json',
+          'application/x-www-form-urlencoded'
+        ]
+        const shouldEncodeJSON = contentTypesNotToEncode.some(type =>
+          contentType.toLowerCase().indexOf(type) === 0
+        )
         // transparently support JSON encoding
         body = shouldEncodeJSON ? JSON.stringify(this.request.body) : this.request.body
         // update origin request headers after encoding

--- a/index.js
+++ b/index.js
@@ -80,7 +80,10 @@ module.exports = fp(function from (fastify, opts, next) {
         // detect if body should be encoded as JSON
         // supporting extended content-type header formats:
         // - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
-        const plainContentType = contentType.toLowerCase().split(';')[0]
+        const lowerCaseContentType = contentType.toLowerCase()
+        const plainContentType = lowerCaseContentType.indexOf(';') > -1
+          ? lowerCaseContentType.slice(0, lowerCaseContentType.indexOf(';'))
+          : lowerCaseContentType
         const shouldEncodeJSON = contentTypesToEncode.has(plainContentType)
         // transparently support JSON encoding
         body = shouldEncodeJSON ? JSON.stringify(this.request.body) : this.request.body

--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ const {
 const { TimeoutError } = buildRequest
 
 module.exports = fp(function from (fastify, opts, next) {
+  const contentTypesToEncode = new Set([
+    'application/json',
+    ...(opts.contentTypesToEncode || [])
+  ])
   const cache = opts.disableCache ? undefined : lru(opts.cacheURLs || 100)
   const base = opts.base
   const { request, close } = buildRequest({
@@ -76,10 +80,6 @@ module.exports = fp(function from (fastify, opts, next) {
         // detect if body should be encoded as JSON
         // supporting extended content-type header formats:
         // - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
-        const contentTypesToEncode = new Set([
-          'application/json',
-          ...(opts.contentTypesToEncode || [])
-        ])
         const lowerCaseContentType = contentType.toLowerCase()
         const plainContentType = lowerCaseContentType.indexOf(';') > -1
           ? lowerCaseContentType.slice(0, lowerCaseContentType.indexOf(';'))

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^14.14.2",
     "@types/tap": "^14.10.1",
     "fastify": "^3.7.0",
+    "fastify-formbody": "^5.0.0",
     "fastify-multipart": "^4.0.0",
     "form-data": "^4.0.0",
     "got": "^11.8.0",

--- a/test/post-formbody.js
+++ b/test/post-formbody.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From)
+instance.register(require('fastify-formbody'))
+
+t.plan(9)
+t.tearDown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'POST')
+  t.equal(req.headers['content-type'], 'application/x-www-form-urlencoded')
+  let data = ''
+  req.setEncoding('utf8')
+  req.on('data', (d) => {
+    data += d
+  })
+  req.on('end', () => {
+    const str = data.toString()
+    t.deepEqual(JSON.parse(data), { some: 'info', another: 'detail' })
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/x-www-form-urlencoded')
+    res.end(str)
+  })
+})
+
+instance.post('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`)
+})
+
+t.tearDown(target.close.bind(target))
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(0, (err) => {
+    t.error(err)
+
+    get({
+      url: `http://localhost:${instance.server.address().port}`,
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'some=info&another=detail'
+    }, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'application/x-www-form-urlencoded')
+      t.deepEqual(JSON.parse(data), { some: 'info', another: 'detail' })
+    })
+  })
+})

--- a/test/post-formbody.js
+++ b/test/post-formbody.js
@@ -7,7 +7,9 @@ const http = require('http')
 const get = require('simple-get').concat
 
 const instance = Fastify()
-instance.register(From)
+instance.register(From, {
+  contentTypesToEncode: ['application/x-www-form-urlencoded']
+})
 instance.register(require('fastify-formbody'))
 
 t.plan(9)
@@ -32,9 +34,7 @@ const target = http.createServer((req, res) => {
 })
 
 instance.post('/', (request, reply) => {
-  reply.from(`http://localhost:${target.address().port}`, {
-    contentTypesToEncode: ['application/x-www-form-urlencoded']
-  })
+  reply.from(`http://localhost:${target.address().port}`)
 })
 
 t.tearDown(target.close.bind(target))

--- a/test/post-with-custom-encoded-contenttype.js
+++ b/test/post-with-custom-encoded-contenttype.js
@@ -8,7 +8,9 @@ const get = require('simple-get').concat
 const { parse } = require('querystring')
 
 const instance = Fastify()
-instance.register(From)
+instance.register(From, {
+  contentTypesToEncode: ['application/x-www-form-urlencoded']
+})
 
 instance.addContentTypeParser(
   'application/x-www-form-urlencoded',
@@ -38,9 +40,7 @@ const target = http.createServer((req, res) => {
 })
 
 instance.post('/', (request, reply) => {
-  reply.from(`http://localhost:${target.address().port}`, {
-    contentTypesToEncode: ['application/x-www-form-urlencoded']
-  })
+  reply.from(`http://localhost:${target.address().port}`)
 })
 
 t.tearDown(target.close.bind(target))

--- a/test/post-with-custom-encoded-contenttype.js
+++ b/test/post-with-custom-encoded-contenttype.js
@@ -5,10 +5,16 @@ const Fastify = require('fastify')
 const From = require('..')
 const http = require('http')
 const get = require('simple-get').concat
+const { parse } = require('querystring')
 
 const instance = Fastify()
 instance.register(From)
-instance.register(require('fastify-formbody'))
+
+instance.addContentTypeParser(
+  'application/x-www-form-urlencoded',
+  { parseAs: 'buffer', bodyLimit: 1000 },
+  (req, body, done) => done(null, parse(body.toString()))
+)
 
 t.plan(9)
 t.tearDown(instance.close.bind(instance))


### PR DESCRIPTION
This fixes https://github.com/fastify/fastify-reply-from/issues/117 which is caused by combining `fastify-reply-from` with `fastify-formbody` 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark` (no benchmark on this plugin)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added 
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
