### PR TITLE
fix: undici options should apply on handleUndici

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -120,7 +120,7 @@ function buildRequest (opts) {
       done(new Error('unix socket not supported with undici yet'))
       return
     } else {
-      const options = getUndiciOptions(opts.undici)
+      const options = getUndiciOptions(undiciOpts)
       options.dispatcher = undiciAgent
       pool = new undici.Pool(baseUrl || opts.url.origin, options)
     }
@@ -277,3 +277,5 @@ function getUndiciOptions (opts = {}) {
 
   return res
 }
+
+module.exports.getUndiciOptions = getUndiciOptions

--- a/test/undici-options.js
+++ b/test/undici-options.js
@@ -3,44 +3,71 @@
 const t = require('tap')
 const Fastify = require('fastify')
 const proxyquire = require('proxyquire')
-
-t.plan(1)
-
-class Agent {
-  constructor (opts) {
-    t.strictSame(opts, {
-      connections: 42,
-      pipelining: 24,
-      keepAliveTimeout: 4242,
-      tls: {
-        rejectUnauthorized: false
-      }
-    })
-  }
-}
-
-// original setup in the undici module
-// needed to test a bug
-function undici () {}
-undici.Agent = Agent
-
-const buildRequest = proxyquire('../lib/request.js', {
-  undici
-})
-
-const From = proxyquire('..', {
-  './lib/request.js': buildRequest
-})
+const http = require('http')
+const get = require('simple-get').concat
+const undici = require('undici')
+const { getUndiciOptions } = require('../lib/request')
 
 const instance = Fastify()
 
-instance.register(From, {
-  base: 'http://path/to/somewhere',
-  undici: {
-    connections: 42,
-    pipelining: 24,
-    keepAliveTimeout: 4242
-  }
+t.plan(7)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  res.statusCode = 200
+  res.end('hello world')
 })
 
-instance.ready()
+instance.get('/', (request, reply) => {
+  reply.from()
+})
+
+t.teardown(target.close.bind(target))
+
+target.listen(0, err => {
+  t.error(err)
+
+  const From = proxyquire('..', {
+    './lib/request.js': proxyquire('../lib/request.js', {
+      undici: undiciProxy
+    })
+  })
+
+  instance.register(From, {
+    base: `http://localhost:${target.address().port}`,
+    undici: buildUndiciOptions()
+  })
+
+  instance.listen(0, err => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.statusCode, 200)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})
+
+function undiciProxy () {}
+undiciProxy.Agent = class Agent extends undici.Agent {
+  constructor (opts) {
+    super(opts)
+    t.strictSame(opts, buildUndiciOptions())
+  }
+}
+undiciProxy.Pool = class Pool extends undici.Pool {
+  constructor (url, options) {
+    super(url, options)
+    t.hasStrict(options, buildUndiciOptions())
+  }
+}
+
+function buildUndiciOptions () {
+  return getUndiciOptions({
+    connections: 42,
+    pipelining: 24,
+    keepAliveTimeout: 4242,
+    strictContentLength: false
+  })
+}


### PR DESCRIPTION
Hi, I'm come from https://github.com/fastify/fastify-http-proxy/pull/163 😄 
undici's `strictContentLength` option is not working properly even after upgrading v6, so I dug into this.

I check the code from #179 and found it doesn't respect undici options at the moment of request(handleUndici). 
On requesting `handleUndici`, there's no `opts.undici` actually.
it should follow `undiciOpts` which set up on initialize of  `buildRequest`.

I also rewrote `test/undici-options` to check the options properly 
* for the initial time, on the `undici.Agent`'s constructor
* for the request time, on the `undici.Pool`'s constructor 

I hope this PR merges in and releasing a patch version. 🙏🏻 


#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~ (there's no `benchmark` script in this project)
- [x] tests ~~and/or benchmarks~~ are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
