### PR TITLE
Support passing a function to the queryString option

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,14 @@ Called to get upstream destination, before the request is being sent. Useful whe
 Helpful for a gradual rollout of new services.
 It must return the upstream destination.
 
-#### `queryString`
+#### `queryString` or `queryString(search, reqUrl)`
 
 Replaces the original querystring of the request with what is specified.
 This will be passed to
 [`querystring.stringify`](https://nodejs.org/api/querystring.html#querystring_querystring_stringify_obj_sep_eq_options).
+
+- `object`: accepts an object that will be passed to `querystring.stringify`
+- `function`: function that will return a string with the query parameters e.g. `name=test&type=user`
 
 #### `body`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,9 @@ import {
   SecureClientSessionOptions,
 } from "http2";
 import { Pool } from 'undici'
+type QueryStringFunction = (search: string | undefined, reqUrl: string) => string;
 export interface FastifyReplyFromHooks {
-  queryString?: { [key: string]: unknown };
+  queryString?: { [key: string]: unknown } | QueryStringFunction;
   contentType?: string;
   onResponse?: (
     request: FastifyRequest<RequestGenericInterface, RawServerBase>,

--- a/index.js
+++ b/index.js
@@ -176,6 +176,10 @@ module.exports = fp(function from (fastify, opts, next) {
 }, '>=3')
 
 function getQueryString (search, reqUrl, opts) {
+  if (typeof opts.queryString === 'function') {
+    return '?' + opts.queryString(search, reqUrl)
+  }
+
   if (opts.queryString) {
     return '?' + querystring.stringify(opts.queryString)
   }

--- a/test/full-querystring-rewrite-option-function.js
+++ b/test/full-querystring-rewrite-option-function.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+const querystring = require('querystring')
+
+const instance = Fastify()
+
+t.plan(10)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/world?b=c')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/hello', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}/world?a=b`, {
+    queryString () {
+      return querystring.stringify({ b: 'c' })
+    }
+  })
+})
+
+t.teardown(target.close.bind(target))
+
+target.listen(0, (err) => {
+  t.error(err)
+
+  instance.register(From)
+
+  instance.listen(0, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}/hello?a=b`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})


### PR DESCRIPTION
Add a new option to allow queryString parameter to be a function.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
