### PR TITLE
Update type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ import {
   HTTPMethods,
   FastifyPluginAsync,
   FastifyPluginCallback,
-} from "fastify";
+} from 'fastify';
 
 import {
   IncomingMessage,
@@ -21,7 +21,7 @@ import {
 import {
   RequestOptions as SecureRequestOptions,
   AgentOptions as SecureAgentOptions,
-  Agent as SecureAgent,
+  Agent as SecureAgent
 } from "https";
 import {
   Http2ServerRequest,
@@ -30,11 +30,8 @@ import {
   ClientSessionOptions,
   SecureClientSessionOptions,
 } from "http2";
-import { Pool } from "undici";
-type QueryStringFunction = (
-  search: string | undefined,
-  reqUrl: string
-) => string;
+import { Pool } from 'undici'
+type QueryStringFunction = (search: string | undefined, reqUrl: string) => string;
 export interface FastifyReplyFromHooks {
   queryString?: { [key: string]: unknown } | QueryStringFunction;
   contentType?: string;
@@ -44,8 +41,8 @@ export interface FastifyReplyFromHooks {
     res: RawReplyDefaultExpression<RawServerBase>
   ) => void;
   onError?: (
-    reply: FastifyReply<RawServerBase>,
-    error: { error: Error }
+      reply: FastifyReply<RawServerBase>,
+      error: { error: Error }
   ) => void;
   body?: unknown;
   rewriteHeaders?: (
@@ -57,14 +54,17 @@ export interface FastifyReplyFromHooks {
     headers: Http2IncomingHttpHeaders | IncomingHttpHeaders
   ) => Http2IncomingHttpHeaders | IncomingHttpHeaders;
   getUpstream?: (
-    req: Http2ServerRequest | IncomingMessage,
-    base: string
+      req: Http2ServerRequest | IncomingMessage,
+      base: string
   ) => string;
 }
 
 declare module "fastify" {
   interface FastifyReply {
-    from(source?: string, opts?: FastifyReplyFromHooks): void;
+    from(
+      source?: string,
+      opts?: FastifyReplyFromHooks
+    ): void;
   }
 }
 
@@ -78,7 +78,7 @@ interface Http2Options {
 interface HttpOptions {
   agentOptions?: AgentOptions | SecureAgentOptions;
   requestOptions?: RequestOptions | SecureRequestOptions;
-  agents?: { "http:": Agent; "https:": SecureAgent };
+  agents?: { 'http:': Agent, 'https:': SecureAgent }
 }
 
 export interface FastifyReplyFromOptions {
@@ -89,7 +89,7 @@ export interface FastifyReplyFromOptions {
   http2?: Http2Options | boolean;
   undici?: Pool.Options;
   contentTypesToEncode?: string[];
-  retryMethods?: (HTTPMethods | "TRACE")[];
+  retryMethods?: (HTTPMethods | 'TRACE')[];
   maxRetriesOn503?: number;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,12 @@
 import {
   FastifyRequest,
   FastifyReply,
-  FastifyPlugin,
   RawReplyDefaultExpression,
   RawServerBase,
   RequestGenericInterface,
   HTTPMethods,
+  FastifyPluginAsync,
+  FastifyPluginCallback,
 } from "fastify";
 
 import {
@@ -92,5 +93,7 @@ export interface FastifyReplyFromOptions {
   maxRetriesOn503?: number;
 }
 
-declare const fastifyReplyFrom: FastifyPlugin<FastifyReplyFromOptions>;
+declare const fastifyReplyFrom:
+  | FastifyPluginCallback<FastifyReplyFromOptions>
+  | FastifyPluginAsync<FastifyReplyFromOptions>;
 export default fastifyReplyFrom;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,9 @@ import {
   FastifyPlugin,
   RawReplyDefaultExpression,
   RawServerBase,
-  RequestGenericInterface
-} from 'fastify';
+  RequestGenericInterface,
+  HTTPMethods,
+} from "fastify";
 
 import {
   IncomingMessage,
@@ -19,7 +20,7 @@ import {
 import {
   RequestOptions as SecureRequestOptions,
   AgentOptions as SecureAgentOptions,
-  Agent as SecureAgent
+  Agent as SecureAgent,
 } from "https";
 import {
   Http2ServerRequest,
@@ -28,8 +29,11 @@ import {
   ClientSessionOptions,
   SecureClientSessionOptions,
 } from "http2";
-import { Pool } from 'undici'
-type QueryStringFunction = (search: string | undefined, reqUrl: string) => string;
+import { Pool } from "undici";
+type QueryStringFunction = (
+  search: string | undefined,
+  reqUrl: string
+) => string;
 export interface FastifyReplyFromHooks {
   queryString?: { [key: string]: unknown } | QueryStringFunction;
   contentType?: string;
@@ -39,8 +43,8 @@ export interface FastifyReplyFromHooks {
     res: RawReplyDefaultExpression<RawServerBase>
   ) => void;
   onError?: (
-      reply: FastifyReply<RawServerBase>,
-      error: { error: Error }
+    reply: FastifyReply<RawServerBase>,
+    error: { error: Error }
   ) => void;
   body?: unknown;
   rewriteHeaders?: (
@@ -52,17 +56,14 @@ export interface FastifyReplyFromHooks {
     headers: Http2IncomingHttpHeaders | IncomingHttpHeaders
   ) => Http2IncomingHttpHeaders | IncomingHttpHeaders;
   getUpstream?: (
-      req: Http2ServerRequest | IncomingMessage,
-      base: string
+    req: Http2ServerRequest | IncomingMessage,
+    base: string
   ) => string;
 }
 
 declare module "fastify" {
   interface FastifyReply {
-    from(
-      source?: string,
-      opts?: FastifyReplyFromHooks
-    ): void;
+    from(source?: string, opts?: FastifyReplyFromHooks): void;
   }
 }
 
@@ -76,7 +77,7 @@ interface Http2Options {
 interface HttpOptions {
   agentOptions?: AgentOptions | SecureAgentOptions;
   requestOptions?: RequestOptions | SecureRequestOptions;
-  agents?: { 'http:': Agent, 'https:': SecureAgent }
+  agents?: { "http:": Agent; "https:": SecureAgent };
 }
 
 export interface FastifyReplyFromOptions {
@@ -86,13 +87,10 @@ export interface FastifyReplyFromOptions {
   http?: HttpOptions;
   http2?: Http2Options | boolean;
   undici?: Pool.Options;
-  keepAliveMsecs?: number;
-  maxFreeSockets?: number;
-  maxSockets?: number;
-  rejectUnauthorized?: boolean;
-  sessionTimeout?: number;
   contentTypesToEncode?: string[];
+  retryMethods?: (HTTPMethods | "TRACE")[];
+  maxRetriesOn503?: number;
 }
 
-declare const fastifyReplyFrom: FastifyPlugin<FastifyReplyFromOptions>
+declare const fastifyReplyFrom: FastifyPlugin<FastifyReplyFromOptions>;
 export default fastifyReplyFrom;

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,13 +1,13 @@
 import replyFrom, { FastifyReplyFromOptions } from "../";
-import fastify, { FastifyReply, RawServerBase } from "fastify";
+import fastify, {FastifyReply, RawServerBase} from "fastify";
 import { AddressInfo } from "net";
 import { IncomingHttpHeaders } from "http2";
-import { expectType } from "tsd";
-import * as http from "http";
-import * as https from "https";
-import * as http2 from "http2";
+import { expectType } from 'tsd';
+import * as http from 'http';
+import * as https from 'https';
+import * as http2 from 'http2';
 // @ts-ignore
-import tap from "tap";
+import tap from 'tap'
 
 const fullOptions: FastifyReplyFromOptions = {
   base: "http://example2.com",
@@ -15,34 +15,34 @@ const fullOptions: FastifyReplyFromOptions = {
     agentOptions: {
       keepAliveMsecs: 60 * 1000,
       maxFreeSockets: 2048,
-      maxSockets: 2048,
+      maxSockets: 2048
     },
     requestOptions: {
-      timeout: 1000,
+      timeout: 1000
     },
     agents: {
-      "http:": new http.Agent({}),
-      "https:": new https.Agent({}),
-    },
+      'http:': new http.Agent({}),
+      'https:': new https.Agent({})
+    }
   },
   http2: {
     sessionTimeout: 1000,
     requestTimeout: 1000,
     sessionOptions: {
-      rejectUnauthorized: true,
+      rejectUnauthorized: true
     },
     requestOptions: {
-      endStream: true,
-    },
+      endStream: true
+    }
   },
   cacheURLs: 100,
   disableCache: false,
   undici: {
     connections: 100,
-    pipelining: 10,
+    pipelining: 10
   },
-  contentTypesToEncode: ["application/x-www-form-urlencoded"],
-  retryMethods: ["GET", "HEAD", "OPTIONS", "TRACE"],
+  contentTypesToEncode: ['application/x-www-form-urlencoded'],
+  retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
   maxRetriesOn503: 10,
 };
 tap.autoend(false);
@@ -54,64 +54,64 @@ async function main() {
 
   server.register(replyFrom, {});
 
-  server.register(replyFrom, { http2: true });
+  server.register(replyFrom, {http2: true});
 
   server.register(replyFrom, fullOptions);
 
   server.get("/v1", (request, reply) => {
-    reply.from();
+      reply.from();
   });
   server.get("/v3", (request, reply) => {
-    reply.from("/v3", {
-      body: { hello: "world" },
-      rewriteRequestHeaders(req, headers) {
-        expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
-        return headers;
-      },
-      getUpstream(req, base) {
-        expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
-        return base;
-      },
-    });
+      reply.from("/v3", {
+          body: {hello: "world"},
+          rewriteRequestHeaders(req, headers) {
+              expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
+              return headers;
+          },
+          getUpstream(req, base) {
+              expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
+              return base;
+          }
+      });
   });
 
-  // http2
-  const instance = fastify({ http2: true });
+// http2
+  const instance = fastify({http2: true});
   // @ts-ignore
   tap.tearDown(instance.close.bind(instance));
-  const target = fastify({ http2: true });
+  const target = fastify({http2: true});
   // @ts-ignore
   tap.tearDown(target.close.bind(target));
   instance.get("/", (request, reply) => {
-    reply.from();
+      reply.from();
   });
 
   instance.get("/http2", (request, reply) => {
-    reply.from("/", {
-      rewriteHeaders(headers, req) {
-        return headers;
-      },
-      rewriteRequestHeaders(req, headers: IncomingHttpHeaders) {
-        return headers;
-      },
-      getUpstream(req, base) {
-        return base;
-      },
-      onError(reply: FastifyReply<RawServerBase>, error) {
-        return reply.send(error.error);
-      },
-    });
+      reply.from("/", {
+          rewriteHeaders(headers, req) {
+              return headers;
+          },
+          rewriteRequestHeaders(req, headers: IncomingHttpHeaders) {
+              return headers;
+          },
+          getUpstream(req, base) {
+              return base;
+          },
+          onError(reply: FastifyReply<RawServerBase>, error) {
+              return reply.send(error.error);
+          }
+      });
   });
 
   await target.listen(0);
   const port = (target.server.address() as AddressInfo).port;
   instance.register(replyFrom, {
-    base: `http://localhost:${port}`,
-    http2: {
-      sessionOptions: {
-        rejectUnauthorized: false,
+      base: `http://localhost:${port}`,
+      http2: {
+        sessionOptions: {
+          rejectUnauthorized: false,
+        },
       },
-    },
   });
   await instance.listen(0);
 
@@ -120,12 +120,12 @@ async function main() {
     base: "http://example2.com",
     undici: {
       pipelining: 10,
-      connections: 10,
-    },
+      connections: 10
+    }
   });
   await undiciInstance.ready();
 
-  tap.pass("done");
+  tap.pass('done');
   tap.end();
 }
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,13 +1,13 @@
 import replyFrom, { FastifyReplyFromOptions } from "../";
-import fastify, {FastifyReply, RawServerBase} from "fastify";
+import fastify, { FastifyReply, RawServerBase } from "fastify";
 import { AddressInfo } from "net";
 import { IncomingHttpHeaders } from "http2";
-import { expectType } from 'tsd';
-import * as http from 'http';
-import * as https from 'https';
-import * as http2 from 'http2';
+import { expectType } from "tsd";
+import * as http from "http";
+import * as https from "https";
+import * as http2 from "http2";
 // @ts-ignore
-import tap from 'tap'
+import tap from "tap";
 
 const fullOptions: FastifyReplyFromOptions = {
   base: "http://example2.com",
@@ -15,37 +15,35 @@ const fullOptions: FastifyReplyFromOptions = {
     agentOptions: {
       keepAliveMsecs: 60 * 1000,
       maxFreeSockets: 2048,
-      maxSockets: 2048
+      maxSockets: 2048,
     },
     requestOptions: {
-      timeout: 1000
+      timeout: 1000,
     },
     agents: {
-      'http:': new http.Agent({}),
-      'https:': new https.Agent({})
-    }
+      "http:": new http.Agent({}),
+      "https:": new https.Agent({}),
+    },
   },
   http2: {
     sessionTimeout: 1000,
     requestTimeout: 1000,
     sessionOptions: {
-      rejectUnauthorized: true
+      rejectUnauthorized: true,
     },
     requestOptions: {
-      endStream: true
-    }
+      endStream: true,
+    },
   },
   cacheURLs: 100,
   disableCache: false,
-  keepAliveMsecs: 60 * 1000,
-  maxFreeSockets: 2048,
-  maxSockets: 2048,
-  rejectUnauthorized: true,
   undici: {
     connections: 100,
-    pipelining: 10
+    pipelining: 10,
   },
-  contentTypesToEncode: ['application/x-www-form-urlencoded']
+  contentTypesToEncode: ["application/x-www-form-urlencoded"],
+  retryMethods: ["GET", "HEAD", "OPTIONS", "TRACE"],
+  maxRetriesOn503: 10,
 };
 tap.autoend(false);
 
@@ -56,61 +54,64 @@ async function main() {
 
   server.register(replyFrom, {});
 
-  server.register(replyFrom, {http2: true});
+  server.register(replyFrom, { http2: true });
 
   server.register(replyFrom, fullOptions);
 
   server.get("/v1", (request, reply) => {
-      reply.from();
+    reply.from();
   });
   server.get("/v3", (request, reply) => {
-      reply.from("/v3", {
-          body: {hello: "world"},
-          rewriteRequestHeaders(req, headers) {
-              expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
-              return headers;
-          },
-          getUpstream(req, base) {
-              expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
-              return base;
-          }
-      });
+    reply.from("/v3", {
+      body: { hello: "world" },
+      rewriteRequestHeaders(req, headers) {
+        expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
+        return headers;
+      },
+      getUpstream(req, base) {
+        expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
+        return base;
+      },
+    });
   });
 
-// http2
-  const instance = fastify({http2: true});
+  // http2
+  const instance = fastify({ http2: true });
   // @ts-ignore
   tap.tearDown(instance.close.bind(instance));
-  const target = fastify({http2: true});
+  const target = fastify({ http2: true });
   // @ts-ignore
   tap.tearDown(target.close.bind(target));
   instance.get("/", (request, reply) => {
-      reply.from();
+    reply.from();
   });
 
   instance.get("/http2", (request, reply) => {
-      reply.from("/", {
-          rewriteHeaders(headers, req) {
-              return headers;
-          },
-          rewriteRequestHeaders(req, headers: IncomingHttpHeaders) {
-              return headers;
-          },
-          getUpstream(req, base) {
-              return base;
-          },
-          onError(reply: FastifyReply<RawServerBase>, error) {
-              return reply.send(error.error);
-          }
-      });
+    reply.from("/", {
+      rewriteHeaders(headers, req) {
+        return headers;
+      },
+      rewriteRequestHeaders(req, headers: IncomingHttpHeaders) {
+        return headers;
+      },
+      getUpstream(req, base) {
+        return base;
+      },
+      onError(reply: FastifyReply<RawServerBase>, error) {
+        return reply.send(error.error);
+      },
+    });
   });
 
   await target.listen(0);
   const port = (target.server.address() as AddressInfo).port;
   instance.register(replyFrom, {
-      base: `http://localhost:${port}`,
-      http2: true,
-      rejectUnauthorized: false
+    base: `http://localhost:${port}`,
+    http2: {
+      sessionOptions: {
+        rejectUnauthorized: false,
+      },
+    },
   });
   await instance.listen(0);
 
@@ -119,12 +120,12 @@ async function main() {
     base: "http://example2.com",
     undici: {
       pipelining: 10,
-      connections: 10
-    }
+      connections: 10,
+    },
   });
   await undiciInstance.ready();
 
-  tap.pass('done');
+  tap.pass("done");
   tap.end();
 }
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -113,6 +113,10 @@ async function main() {
         },
       },
   });
+  instance.register(replyFrom, {
+    base: `http://localhost:${port}`,
+    http2: true,
+});
   await instance.listen(0);
 
   const undiciInstance = fastify();


### PR DESCRIPTION
Fixes #233 

One thing I am not so happy with is `retryMethods?: (HTTPMethods | "TRACE")[];`, but unfortunately `TRACE` [is not included](https://github.com/fastify/fastify/blob/main/types/utils.d.ts#L8) in `HTTPMethods`.