### PR TITLE
Allow empty body override

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Replaces the original request body with what is specified. Unless
 [`contentType`](#contentType) is specified, the content will be passed
 through `JSON.stringify()`.
 Setting this option for GET, HEAD requests will throw an error "Rewriting the body when doing a {GET|HEAD} is not allowed".
+Setting this option to `undefined` will strip the body (and `content-type` header) entirely from the proxied request.
 
 #### `retriesCount`
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Replaces the original request body with what is specified. Unless
 [`contentType`](#contentType) is specified, the content will be passed
 through `JSON.stringify()`.
 Setting this option for GET, HEAD requests will throw an error "Rewriting the body when doing a {GET|HEAD} is not allowed".
-Setting this option to `undefined` will strip the body (and `content-type` header) entirely from the proxied request.
+Setting this option to `null` will strip the body (and `content-type` header) entirely from the proxied request.
 
 #### `retriesCount`
 

--- a/index.js
+++ b/index.js
@@ -65,8 +65,8 @@ module.exports = fp(function from (fastify, opts, next) {
     const qs = getQueryString(url.search, req.url, opts)
     let body = ''
 
-    if ('body' in opts) {
-      if (opts.body !== undefined) {
+    if (opts.body !== undefined) {
+      if (opts.body !== null) {
         if (typeof opts.body.pipe === 'function') {
           throw new Error('sending a new body as a stream is not supported yet')
         }

--- a/test/full-rewrite-body-to-null.js
+++ b/test/full-rewrite-body-to-null.js
@@ -34,7 +34,7 @@ const target = http.createServer((req, res) => {
 
 instance.post('/', (request, reply) => {
   reply.from(`http://localhost:${target.address().port}`, {
-    body: undefined
+    body: null
   })
 })
 

--- a/test/full-rewrite-body-to-undefined.js
+++ b/test/full-rewrite-body-to-undefined.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From, {
+  http: true
+})
+
+t.plan(9)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'POST')
+  t.notOk('content-type' in req.headers)
+  t.equal(req.headers['content-length'], '0')
+  let data = ''
+  req.setEncoding('utf8')
+  req.on('data', (d) => {
+    data += d
+  })
+  req.on('end', () => {
+    t.equal(data.length, 0)
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ hello: 'fastify' }))
+  })
+})
+
+instance.post('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`, {
+    body: undefined
+  })
+})
+
+t.teardown(target.close.bind(target))
+
+instance.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(0, (err) => {
+    t.error(err)
+
+    get({
+      url: `http://localhost:${instance.server.address().port}`,
+      method: 'POST',
+      json: true,
+      body: {
+        hello: 'world'
+      }
+    }, (err, res, data) => {
+      t.error(err)
+      t.same(data, { hello: 'fastify' })
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Currently it is not possible to modify the proxied body to be undefined or an empty string since both of these values are falsy and the current implementation checks for the truthiness of `opts.body`.  This PR changes the behavior to check for the existence of `opts.body` instead (`"body" in opts`) to allow falsy values to be sent.

This would potentially be a breaking change since `fastify-reply-from` currently ignores the `body` param when it is set to `undefined` or an empty string.  The current empty string behavior feels unexpected, while the current behavior for `undefined` may be desired.  If that's the case, this could be reworked to have a more explicit way to strip the body, such as a new `doNotSendBody` option.

#### Test Results

```
  🌈 SUMMARY RESULTS 🌈


Suites:   72 passed, 72 of 72 completed
Asserts:  607 passed, of 607
Time:   20s
------------------------|---------|----------|---------|---------|-------------------
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------------|---------|----------|---------|---------|-------------------
All files               |   97.98 |     95.7 |     100 |   98.64 |
 fastify-reply-from     |     100 |    99.05 |     100 |     100 |
  index.js              |     100 |    99.05 |     100 |     100 | 93
 fastify-reply-from/lib |   96.51 |    92.91 |     100 |   97.63 |
  request.js            |   96.47 |     92.3 |     100 |   97.84 | 47,51,224
  utils.js              |   96.66 |    95.65 |     100 |   96.66 | 9
------------------------|---------|----------|---------|---------|-------------------
```

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
