### PR TITLE
feat(#232): added option disableRequestLogging to disable request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ proxy.register(require('@fastify/reply-from'), {
 })
 ```
 
+#### `disableRequestLogging`
+
+By default package will issue log messages when a request is received. By setting this option to true, these log messages will be disabled.
+
+Default for `disableRequestLogging` will be `false`. To disable the log messages set `disableRequestLogging` to `true`.
+
+```js
+proxy.register(require('@fastify/reply-from'), {
+  base: 'http://localhost:3001/',
+  disableRequestLogging: true // request log messages will be disabled
+})
+```
+
 #### `cacheURLs`
 
 The number of parsed URLs that will be cached. Default: `100`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,7 @@ export interface FastifyReplyFromOptions {
   contentTypesToEncode?: string[];
   retryMethods?: (HTTPMethods | 'TRACE')[];
   maxRetriesOn503?: number;
+  disableRequestLogging?: boolean;
 }
 
 declare const fastifyReplyFrom:

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = fp(function from (fastify, opts, next) {
     base,
     undici: opts.undici
   })
+  const disableRequestLogging = opts.disableRequestLogging || false
 
   fastify.decorateReply('from', function (source, opts) {
     opts = opts || {}
@@ -120,7 +121,7 @@ module.exports = fp(function from (fastify, opts, next) {
       }
     }
 
-    this.request.log.info({ source }, 'fetching from remote server')
+    !disableRequestLogging && this.request.log.info({ source }, 'fetching from remote server')
 
     const requestHeaders = rewriteRequestHeaders(req, headers)
     const contentLength = requestHeaders['content-length']
@@ -145,7 +146,7 @@ module.exports = fp(function from (fastify, opts, next) {
         }
         return
       }
-      this.request.log.info('response received')
+      !disableRequestLogging && this.request.log.info('response received')
       if (sourceHttp2) {
         copyHeaders(
           rewriteHeaders(stripHttp1ConnectionHeaders(res.headers), req),

--- a/test/disable-request-logging.js
+++ b/test/disable-request-logging.js
@@ -1,0 +1,159 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+const split = require('split2')
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/')
+  t.equal(req.headers.connection, 'keep-alive')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+t.test('use a custom instance of \'undici\'', async t => {
+  t.teardown(target.close.bind(target))
+
+  await new Promise((resolve, reject) => target.listen({ port: 0 }, err => err ? reject(err) : resolve()))
+
+  t.test('disableRequestLogging is set to true', t => {
+    t.plan(10)
+    const logStream = split(JSON.parse)
+    const instance = Fastify({
+      logger: {
+        level: 'info',
+        stream: logStream
+      }
+    })
+    t.teardown(instance.close.bind(instance))
+    instance.register(From, {
+      base: `http://localhost:${target.address().port}`,
+      disableRequestLogging: true
+    })
+
+    instance.get('/', (request, reply) => {
+      reply.from()
+    })
+
+    logStream.on('data', (log) => {
+      if (
+        log.level === 30 &&
+        (
+          !log.msg.match('response received') ||
+          !log.msg.match('fetching from remote server')
+        )
+      ) {
+        t.pass('request log message does not logged')
+      }
+    })
+
+    instance.listen({ port: 0 }, (err) => {
+      t.error(err)
+
+      get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+        t.error(err)
+        t.equal(res.headers['content-type'], 'text/plain')
+        t.equal(res.headers['x-my-header'], 'hello!')
+        t.equal(res.statusCode, 205)
+        t.equal(data.toString(), 'hello world')
+        t.end()
+      })
+    })
+  })
+
+  t.test('disableRequestLogging is set to false', t => {
+    t.plan(8)
+    const logStream = split(JSON.parse)
+    const instance = Fastify({
+      logger: {
+        level: 'info',
+        stream: logStream
+      }
+    })
+    t.teardown(instance.close.bind(instance))
+    instance.register(From, {
+      base: `http://localhost:${target.address().port}`,
+      disableRequestLogging: false
+    })
+
+    instance.get('/', (request, reply) => {
+      reply.from()
+    })
+
+    logStream.on('data', (log) => {
+      if (
+        log.level === 30 &&
+        (
+          log.msg.match('response received') ||
+          log.msg.match('fetching from remote server')
+        )
+      ) {
+        t.pass('request log message does not logged')
+      }
+    })
+
+    instance.listen({ port: 0 }, (err) => {
+      t.error(err)
+
+      get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+        t.error(err)
+        t.equal(res.headers['content-type'], 'text/plain')
+        t.equal(res.headers['x-my-header'], 'hello!')
+        t.equal(res.statusCode, 205)
+        t.equal(data.toString(), 'hello world')
+        t.end()
+      })
+    })
+  })
+
+  t.test('disableRequestLogging is not defined', t => {
+    t.plan(8)
+    const logStream = split(JSON.parse)
+    const instance = Fastify({
+      logger: {
+        level: 'info',
+        stream: logStream
+      }
+    })
+    t.teardown(instance.close.bind(instance))
+    instance.register(From, {
+      base: `http://localhost:${target.address().port}`
+    })
+
+    instance.get('/', (request, reply) => {
+      reply.from()
+    })
+
+    logStream.on('data', (log) => {
+      if (
+        log.level === 30 &&
+        (
+          log.msg.match('response received') ||
+          log.msg.match('fetching from remote server')
+        )
+      ) {
+        t.pass('request log message does not logged')
+      }
+    })
+
+    instance.listen({ port: 0 }, (err) => {
+      t.error(err)
+
+      get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+        t.error(err)
+        t.equal(res.headers['content-type'], 'text/plain')
+        t.equal(res.headers['x-my-header'], 'hello!')
+        t.equal(res.statusCode, 205)
+        t.equal(data.toString(), 'hello world')
+        t.end()
+      })
+    })
+  })
+})

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -44,6 +44,7 @@ const fullOptions: FastifyReplyFromOptions = {
   contentTypesToEncode: ['application/x-www-form-urlencoded'],
   retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
   maxRetriesOn503: 10,
+  disableRequestLogging: false,
 };
 tap.autoend(false);
 


### PR DESCRIPTION
added disableRequestLogging (optional) to fastify-reply-from  to disable request logging #232 
#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
