### PR TITLE
fix: wrong FastifyReplyFromOptions.http type, could be boolean

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ export interface FastifyReplyFromOptions {
   base?: string;
   cacheURLs?: number;
   disableCache?: boolean;
-  http?: HttpOptions;
+  http?: HttpOptions | boolean;
   http2?: Http2Options | boolean;
   undici?: Pool.Options;
   contentTypesToEncode?: string[];


### PR DESCRIPTION
The documentation specifies here https://github.com/fastify/fastify-reply-from#http that the http props can be a boolean

This is confirmed by this line of code
https://github.com/fastify/fastify-reply-from/blob/5b16f63f6de321f6a5be16b9e89b74182d47092f/lib/request.js#L256

But not in the type definition