### PR TITLE
Revert "fix: wrong FastifyReplyFromOptions.http type, could be boolean"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ export interface FastifyReplyFromOptions {
   base?: string;
   cacheURLs?: number;
   disableCache?: boolean;
-  http?: HttpOptions | boolean;
+  http?: HttpOptions;
   http2?: Http2Options | boolean;
   undici?: Pool.Options;
   contentTypesToEncode?: string[];


### PR DESCRIPTION
Reverts fastify/fastify-reply-from#266

Imho the http can not be boolean. 

https://github.com/fastify/fastify-reply-from/blob/5b16f63f6de321f6a5be16b9e89b74182d47092f/lib/request.js#L256

The code itself just checks if it is an Object then assign it to httpOpts. If you assign anything else, than it will generate an empty Object. So basically, httpOpts is always an Object, no matter if you assign false or true to it. 
