### PR TITLE
fix: verify reply.from() return type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,7 +63,7 @@ declare module "fastify" {
     from(
       source?: string,
       opts?: FastifyReplyFromHooks
-    ): void;
+    ): this;
   }
 }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -60,7 +60,8 @@ async function main() {
   server.register(replyFrom, fullOptions);
 
   server.get("/v1", (request, reply) => {
-      reply.from();
+      // Verify the return type of reply.from()
+      const newReply: FastifyReply = reply.from();
   });
   server.get("/v3", (request, reply) => {
       reply.from("/v3", {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -60,8 +60,7 @@ async function main() {
   server.register(replyFrom, fullOptions);
 
   server.get("/v1", (request, reply) => {
-      // Verify the return type of reply.from()
-      const newReply: FastifyReply = reply.from();
+      expectType<FastifyReply>(reply.from());
   });
   server.get("/v3", (request, reply) => {
       reply.from("/v3", {


### PR DESCRIPTION
Hi! :wave:

I noticed that `reply.from(…)`'s return type is `void`, while in reality it returns the `reply` (like most/all other plugins that decorate the `reply`).

I updated the type, and added a type check to one of the existing tests to verify the fix.

Do you think this looks reasonable?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added **(not applicable, I think)**
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md) **(I think – I'm not 100 % sure what exactly this entails)**
