### PR TITLE
fix: undici headers

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -5,7 +5,7 @@ const querystring = require('querystring')
 const eos = require('end-of-stream')
 const pump = require('pump')
 const undici = require('undici')
-const { stripHttp1ConnectionHeaders } = require('./utils')
+const { patchUndiciHeaders, stripHttp1ConnectionHeaders } = require('./utils')
 const http2 = require('http2')
 
 const {
@@ -158,7 +158,7 @@ function buildRequest (opts) {
       // using delete, otherwise it will render as an empty string
       delete res.headers['transfer-encoding']
 
-      done(null, { statusCode: res.statusCode, headers: res.headers, stream: res.body })
+      done(null, { statusCode: res.statusCode, headers: patchUndiciHeaders(res.headers), stream: res.body })
     })
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,31 @@ function filterPseudoHeaders (headers) {
   return dest
 }
 
+// http required the header to be encoded with latin1
+// undici will convert the latin1 buffer back to utf8
+// https://github.com/nodejs/undici/blob/2b260c997ad4efe4ed2064b264b4b546a59e7a67/lib/core/util.js#L216-L229
+// after chaining, the header will converted in wrong byte
+// Buffer.from('', 'latin1').toString('utf8') applied
+//
+// in order to presist the encoding, always encode it
+// back to latin1
+function patchUndiciHeaders (headers) {
+  const headersKeys = Object.keys(headers)
+  const dist = {}
+
+  let header
+  let i
+
+  for (i = 0; i < headersKeys.length; i++) {
+    header = headersKeys[i]
+    if (header.charCodeAt(0) !== 58) { // fast path for indexOf(':') === 0
+      dist[header] = Buffer.from(headers[header]).toString('latin1')
+    }
+  }
+
+  return dist
+}
+
 function copyHeaders (headers, reply) {
   const headersKeys = Object.keys(headers)
 
@@ -74,6 +99,7 @@ function buildURL (source, reqBase) {
 }
 
 module.exports = {
+  patchUndiciHeaders,
   copyHeaders,
   stripHttp1ConnectionHeaders,
   filterPseudoHeaders,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,13 +12,13 @@ function filterPseudoHeaders (headers) {
   return dest
 }
 
-// http required the header to be encoded with latin1
-// undici will convert the latin1 buffer back to utf8
+// http requires the header to be encoded with latin1
+// undici will convert the latin1 buffer to utf8
 // https://github.com/nodejs/undici/blob/2b260c997ad4efe4ed2064b264b4b546a59e7a67/lib/core/util.js#L216-L229
-// after chaining, the header will converted in wrong byte
+// after chaining, the header will be serialised using wrong encoding
 // Buffer.from('', 'latin1').toString('utf8') applied
 //
-// in order to presist the encoding, always encode it
+// in order to persist the encoding, always encode it
 // back to latin1
 function patchUndiciHeaders (headers) {
   const headersKeys = Object.keys(headers)

--- a/test/undici-chaining.js
+++ b/test/undici-chaining.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const get = require('simple-get').concat
+const From = require('..')
+
+const header = 'attachment; filename="år.pdf"'
+
+t.plan(6)
+
+const instance = Fastify()
+t.teardown(instance.close.bind(instance))
+instance.listen({ port: 0 })
+
+const proxy1 = Fastify()
+t.teardown(proxy1.close.bind(proxy1))
+const proxy2 = Fastify()
+t.teardown(proxy2.close.bind(proxy2))
+
+instance.get('/', (request, reply) => {
+  reply.header('content-disposition', header).send('OK')
+})
+
+proxy1.register(From)
+proxy1.get('/', (request, reply) => {
+  return reply.from(`http://localhost:${instance.server.address().port}`)
+})
+
+proxy2.register(From)
+proxy2.get('/', (request, reply) => {
+  return reply.from(`http://localhost:${proxy1.server.address().port}`)
+})
+
+instance.listen({ port: 0 }, err => {
+  t.error(err)
+
+  proxy1.listen({ port: 0 }, err => {
+    t.error(err)
+
+    proxy2.listen({ port: 0 }, err => {
+      t.error(err)
+
+      get(`http://localhost:${proxy2.server.address().port}`, (err, res, data) => {
+        t.error(err)
+        t.equal(res.statusCode, 200)
+        t.equal(data.toString(), 'OK')
+      })
+    })
+  })
+})

--- a/test/undici-chaining.js
+++ b/test/undici-chaining.js
@@ -11,8 +11,6 @@ t.plan(6)
 
 const instance = Fastify()
 t.teardown(instance.close.bind(instance))
-instance.listen({ port: 0 })
-
 const proxy1 = Fastify()
 t.teardown(proxy1.close.bind(proxy1))
 const proxy2 = Fastify()

--- a/test/undici-chaining.js
+++ b/test/undici-chaining.js
@@ -3,6 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 const get = require('simple-get').concat
+const { getUndiciOptions } = require('../lib/request')
 const From = require('..')
 
 const header = 'attachment; filename="år.pdf"'
@@ -20,12 +21,16 @@ instance.get('/', (request, reply) => {
   reply.header('content-disposition', header).send('OK')
 })
 
-proxy1.register(From)
+proxy1.register(From, {
+  undici: buildUndiciOptions()
+})
 proxy1.get('/', (request, reply) => {
   return reply.from(`http://localhost:${instance.server.address().port}`)
 })
 
-proxy2.register(From)
+proxy2.register(From, {
+  undici: buildUndiciOptions()
+})
 proxy2.get('/', (request, reply) => {
   return reply.from(`http://localhost:${proxy1.server.address().port}`)
 })
@@ -47,3 +52,12 @@ instance.listen({ port: 0 }, err => {
     })
   })
 })
+
+function buildUndiciOptions () {
+  return getUndiciOptions({
+    connections: 42,
+    pipelining: 24,
+    keepAliveTimeout: 4242,
+    strictContentLength: false
+  })
+}

--- a/test/undici-chaining.js
+++ b/test/undici-chaining.js
@@ -3,7 +3,6 @@
 const t = require('tap')
 const Fastify = require('fastify')
 const get = require('simple-get').concat
-const { getUndiciOptions } = require('../lib/request')
 const From = require('..')
 
 const header = 'attachment; filename="år.pdf"'
@@ -22,14 +21,18 @@ instance.get('/', (request, reply) => {
 })
 
 proxy1.register(From, {
-  undici: buildUndiciOptions()
+  undici: {
+    keepAliveMaxTimeout: 10
+  }
 })
 proxy1.get('/', (request, reply) => {
   return reply.from(`http://localhost:${instance.server.address().port}`)
 })
 
 proxy2.register(From, {
-  undici: buildUndiciOptions()
+  undici: {
+    keepAliveMaxTimeout: 10
+  }
 })
 proxy2.get('/', (request, reply) => {
   return reply.from(`http://localhost:${proxy1.server.address().port}`)
@@ -52,12 +55,3 @@ instance.listen({ port: 0 }, err => {
     })
   })
 })
-
-function buildUndiciOptions () {
-  return getUndiciOptions({
-    connections: 42,
-    pipelining: 24,
-    keepAliveTimeout: 4242,
-    strictContentLength: false
-  })
-}


### PR DESCRIPTION
Fixes #287 

Finally found the problem is caused by both `http` and `undici`.
1. `http` is not always treats the `header` to `latin1`.
https://github.com/nodejs/node/blob/2a29df64645a70bbb833298423a29206c4ec6a2e/lib/_http_outgoing.js#L361-L373
2. `undici` always perform `Buffer.from('').toString('utf8')` regardless the `header` encoding.
https://github.com/nodejs/undici/blob/2b260c997ad4efe4ed2064b264b4b546a59e7a67/lib/core/util.js#L216-L229

In combine of the above two problem.
The headers will parsed as a completely difference byte when chaining.

In this fix, we always treats the header as `latin1`. 
So, we are always consistence in the encoding.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
