### PR TITLE
Revert "fix: undici headers (#289)"

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -5,7 +5,7 @@ const querystring = require('querystring')
 const eos = require('end-of-stream')
 const pump = require('pump')
 const undici = require('undici')
-const { patchUndiciHeaders, stripHttp1ConnectionHeaders } = require('./utils')
+const { stripHttp1ConnectionHeaders } = require('./utils')
 const http2 = require('http2')
 
 const {
@@ -158,7 +158,7 @@ function buildRequest (opts) {
       // using delete, otherwise it will render as an empty string
       delete res.headers['transfer-encoding']
 
-      done(null, { statusCode: res.statusCode, headers: patchUndiciHeaders(res.headers), stream: res.body })
+      done(null, { statusCode: res.statusCode, headers: res.headers, stream: res.body })
     })
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,31 +12,6 @@ function filterPseudoHeaders (headers) {
   return dest
 }
 
-// http requires the header to be encoded with latin1
-// undici will convert the latin1 buffer to utf8
-// https://github.com/nodejs/undici/blob/2b260c997ad4efe4ed2064b264b4b546a59e7a67/lib/core/util.js#L216-L229
-// after chaining, the header will be serialised using wrong encoding
-// Buffer.from('', 'latin1').toString('utf8') applied
-//
-// in order to persist the encoding, always encode it
-// back to latin1
-function patchUndiciHeaders (headers) {
-  const headersKeys = Object.keys(headers)
-  const dist = {}
-
-  let header
-  let i
-
-  for (i = 0; i < headersKeys.length; i++) {
-    header = headersKeys[i]
-    if (header.charCodeAt(0) !== 58) { // fast path for indexOf(':') === 0
-      dist[header] = Buffer.from(headers[header]).toString('latin1')
-    }
-  }
-
-  return dist
-}
-
 function copyHeaders (headers, reply) {
   const headersKeys = Object.keys(headers)
 
@@ -99,7 +74,6 @@ function buildURL (source, reqBase) {
 }
 
 module.exports = {
-  patchUndiciHeaders,
   copyHeaders,
   stripHttp1ConnectionHeaders,
   filterPseudoHeaders,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fastify-plugin": "^4.0.0",
     "pump": "^3.0.0",
     "tiny-lru": "^10.0.0",
-    "undici": "^5.5.1"
+    "undici": "^5.19.1"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
- Partial revert of 09cb8e75abc221091be5b2b2f75d371277fef76b (keep test case)
- Upgrade `undici@5.19.1` which include security patch

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
