### PR TITLE
Pass Fastify request to callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,20 +296,20 @@ It must reply the error.
 
 Called to rewrite the headers of the response, before them being copied
 over to the outer response.
-Parameters are the original headers and the fastify request.
+Parameters are the original headers and the Fastify request.
 It must return the new headers object.
 
 #### `rewriteRequestHeaders(request, headers)`
 
 Called to rewrite the headers of the request, before them being sent to the other server.
-Parameters are the fastify request and the original request headers.
+Parameters are the Fastify request and the original request headers.
 It must return the new headers object.
 
 #### `getUpstream(request, base)`
 
 Called to get upstream destination, before the request is being sent. Useful when you want to decide which target server to call based on the request data.
 Helpful for a gradual rollout of new services.
-Parameters are the fastify request and the base string from the plugin options.
+Parameters are the Fastify request and the base string from the plugin options.
 It must return the upstream destination.
 
 #### `queryString` or `queryString(search, reqUrl)`

--- a/README.md
+++ b/README.md
@@ -292,21 +292,24 @@ The default behavior is `reply.send(error)`, which will be disabled if the
 option is specified.
 It must reply the error.
 
-#### `rewriteHeaders(headers, req)`
+#### `rewriteHeaders(headers, request)`
 
 Called to rewrite the headers of the response, before them being copied
 over to the outer response.
+Parameters are the original headers and the fastify request.
 It must return the new headers object.
 
-#### `rewriteRequestHeaders(originalReq, headers)`
+#### `rewriteRequestHeaders(request, headers)`
 
 Called to rewrite the headers of the request, before them being sent to the other server.
+Parameters are the fastify request and the original request headers.
 It must return the new headers object.
 
-#### `getUpstream(originalReq, base)`
+#### `getUpstream(request, base)`
 
 Called to get upstream destination, before the request is being sent. Useful when you want to decide which target server to call based on the request data.
 Helpful for a gradual rollout of new services.
+Parameters are the fastify request and the base string from the plugin options.
 It must return the upstream destination.
 
 #### `queryString` or `queryString(search, reqUrl)`

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
     }
 
     // we leverage caching to avoid parsing the destination URL
-    const dest = getUpstream(req, base)
+    const dest = getUpstream(this.request, base)
     let url
     if (cache) {
       const cacheKey = dest + source
@@ -136,7 +136,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
 
     !disableRequestLogging && this.request.log.info({ source }, 'fetching from remote server')
 
-    const requestHeaders = rewriteRequestHeaders(req, headers)
+    const requestHeaders = rewriteRequestHeaders(this.request, headers)
     const contentLength = requestHeaders['content-length']
     let requestImpl
     if (retryMethods.has(req.method) && !contentLength) {
@@ -166,11 +166,11 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
       !disableRequestLogging && this.request.log.info('response received')
       if (sourceHttp2) {
         copyHeaders(
-          rewriteHeaders(stripHttp1ConnectionHeaders(res.headers), req),
+          rewriteHeaders(stripHttp1ConnectionHeaders(res.headers), this.request),
           this
         )
       } else {
-        copyHeaders(rewriteHeaders(res.headers, req), this)
+        copyHeaders(rewriteHeaders(res.headers, this.request), this)
       }
       this.code(res.statusCode)
       if (onResponse) {

--- a/test/get-upstream-type.js
+++ b/test/get-upstream-type.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From, {
+  disableCache: true
+})
+
+t.plan(8)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  res.end(req.headers.host)
+})
+
+instance.get('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`, {
+    getUpstream: (req) => {
+      t.pass('getUpstream called with correct request parameter')
+      t.equal(req, request)
+      return `http://localhost:${target.address().port}`
+    }
+  })
+})
+
+t.teardown(target.close.bind(target))
+
+instance.listen({ port: 0 }, (err) => {
+  t.error(err)
+
+  target.listen({ port: 0 }, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 200)
+    })
+  })
+})

--- a/test/rewrite-headers-type.js
+++ b/test/rewrite-headers-type.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From)
+
+t.plan(8)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  res.statusCode = 205
+  res.end('hello world')
+})
+
+instance.get('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`, {
+    rewriteHeaders: (headers, req) => {
+      t.pass('rewriteHeaders called with correct request parameter')
+      t.equal(req, request)
+      return {}
+    }
+  })
+})
+
+t.teardown(target.close.bind(target))
+
+instance.listen({ port: 0 }, (err) => {
+  t.error(err)
+
+  target.listen({ port: 0 }, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.statusCode, 205)
+    })
+  })
+})

--- a/test/rewrite-request-headers-type.js
+++ b/test/rewrite-request-headers-type.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From)
+
+t.plan(8)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  res.statusCode = 205
+  res.end(req.headers.host)
+})
+
+instance.get('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`, {
+    rewriteRequestHeaders: (originalReq, headers) => {
+      t.pass('rewriteRequestHeaders called with correct request parameter')
+      t.equal(originalReq, request)
+      return {}
+    }
+  })
+})
+
+t.teardown(target.close.bind(target))
+
+instance.listen({ port: 0 }, (err) => {
+  t.error(err)
+
+  target.listen({ port: 0 }, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.statusCode, 205)
+    })
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,6 @@ import {
 } from 'fastify';
 
 import {
-  IncomingMessage,
   IncomingHttpHeaders,
   RequestOptions,
   AgentOptions,
@@ -23,7 +22,6 @@ import {
   Agent as SecureAgent
 } from "https";
 import {
-  Http2ServerRequest,
   IncomingHttpHeaders as Http2IncomingHttpHeaders,
   ClientSessionRequestOptions,
   ClientSessionOptions,
@@ -59,14 +57,14 @@ declare namespace fastifyReplyFrom {
     body?: unknown;
     rewriteHeaders?: (
       headers: Http2IncomingHttpHeaders | IncomingHttpHeaders,
-      req?: Http2ServerRequest | IncomingMessage
+      request?: FastifyRequest<RequestGenericInterface, RawServerBase>
     ) => Http2IncomingHttpHeaders | IncomingHttpHeaders;
     rewriteRequestHeaders?: (
-      req: Http2ServerRequest | IncomingMessage,
+      request: FastifyRequest<RequestGenericInterface, RawServerBase>,
       headers: Http2IncomingHttpHeaders | IncomingHttpHeaders
     ) => Http2IncomingHttpHeaders | IncomingHttpHeaders;
     getUpstream?: (
-      req: Http2ServerRequest | IncomingMessage,
+      request: FastifyRequest<RequestGenericInterface, RawServerBase>,
       base: string
     ) => string;
   }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,11 +1,10 @@
 import replyFrom, { FastifyReplyFromOptions } from "..";
-import fastify, {FastifyReply, RawServerBase} from "fastify";
+import fastify, {FastifyReply, FastifyRequest, RawServerBase, RequestGenericInterface} from "fastify";
 import { AddressInfo } from "net";
 import { IncomingHttpHeaders } from "http2";
 import { expectType } from 'tsd';
 import * as http from 'http';
 import * as https from 'https';
-import * as http2 from 'http2';
 // @ts-ignore
 import tap from 'tap'
 
@@ -67,11 +66,11 @@ async function main() {
       reply.from("/v3", {
           body: {hello: "world"},
           rewriteRequestHeaders(req, headers) {
-              expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
+              expectType<FastifyRequest<RequestGenericInterface, RawServerBase>>(req);
               return headers;
           },
           getUpstream(req, base) {
-              expectType<http.IncomingMessage | http2.Http2ServerRequest>(req);
+              expectType<FastifyRequest<RequestGenericInterface, RawServerBase>>(req);
               return base;
           }
       });


### PR DESCRIPTION
Fixes #72, related to #168.

Currently, the options `rewriteHeaders`, `rewriteRequestHeaders`, and `getUpstream` are all sync-only.
The suggested workaround in #168 was to use hooks to decorate the request, however, only `onResponse` passes in the fastify request, the others passed in the raw request, rendering the decorations inaccessible.

This PR updates the methods above to use the fastify request as the parameter. The old parameter is still accessible at `request.raw`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
