### PR TITLE
Disable http/http2 timeout for sse events

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -112,6 +112,10 @@ function buildRequest (opts) {
     })
     req.on('error', done)
     req.on('response', res => {
+      // remove timeout for sse connections
+      if (res.headers['content-type'] === 'text/event-stream') {
+        req.setTimeout(0)
+      }
       done(null, { statusCode: res.statusCode, headers: res.headers, stream: res })
     })
     req.once('timeout', () => {
@@ -210,6 +214,11 @@ function buildRequest (opts) {
       if (err) done(err)
     })
     req.on('response', headers => {
+      // remove timeout for sse connections
+      if (headers['content-type'] === 'text/event-stream') {
+        req.setTimeout(0)
+      }
+
       const statusCode = headers[':status']
       done(null, { statusCode, headers, stream: req })
     })

--- a/lib/request.js
+++ b/lib/request.js
@@ -214,11 +214,6 @@ function buildRequest (opts) {
       if (err) done(err)
     })
     req.on('response', headers => {
-      // remove timeout for sse connections
-      if (headers['content-type'] === 'text/event-stream') {
-        req.setTimeout(0)
-      }
-
       const statusCode = headers[':status']
       done(null, { statusCode, headers, stream: req })
     })

--- a/lib/request.js
+++ b/lib/request.js
@@ -214,6 +214,12 @@ function buildRequest (opts) {
       if (err) done(err)
     })
     req.on('response', headers => {
+      // remove timeout for sse connections
+      if (headers['content-type'] === 'text/event-stream') {
+        req.setTimeout(0)
+        http2Client.setTimeout(0)
+      }
+
       const statusCode = headers[':status']
       done(null, { statusCode, headers, stream: req })
     })

--- a/test/http2-timeout.test.js
+++ b/test/http2-timeout.test.js
@@ -92,3 +92,34 @@ test('http2 session timeout', async (t) => {
 
   t.fail()
 })
+
+test('http2 sse removes request and session timeout test', async (t) => {
+  const target = Fastify({ http2: true, sessionTimeout: 0 })
+
+  target.get('/', (request, reply) => {
+    t.pass('request arrives')
+
+    reply.status(200).header('content-type', 'text/event-stream').send('hello world')
+  })
+
+  await target.listen({ port: 0 })
+
+  const instance = Fastify()
+
+  instance.register(From, {
+    base: `http://localhost:${target.server.address().port}`,
+    http2: { sessionTimeout: 100 }
+  })
+
+  instance.get('/', (request, reply) => {
+    reply.from(`http://localhost:${target.server.address().port}/`)
+  })
+
+  await instance.listen({ port: 0 })
+
+  t.teardown(instance.close.bind(instance))
+  t.teardown(target.close.bind(target))
+
+  const { statusCode } = await got.get(`http://localhost:${instance.server.address().port}/`, { retry: 0 })
+  t.equal(statusCode, 200)
+})

--- a/test/http2-timeout.test.js
+++ b/test/http2-timeout.test.js
@@ -49,35 +49,6 @@ test('http2 request timeout', async (t) => {
   t.fail()
 })
 
-test('http2 sse removes timeout test', async (t) => {
-  const target = Fastify({ http2: true, sessionTimeout: 0 })
-  t.teardown(target.close.bind(target))
-
-  target.get('/', (request, reply) => {
-    t.pass('request arrives')
-    reply.header('content-type', 'text/event-stream').status(200).send('hello world')
-  })
-
-  await target.listen({ port: 0 })
-
-  const instance = Fastify()
-  t.teardown(instance.close.bind(instance))
-
-  instance.register(From, {
-    base: `http://localhost:${target.server.address().port}`,
-    http2: { requestTimeout: 100 }
-  })
-
-  instance.get('/', (request, reply) => {
-    reply.from(`http://localhost:${target.server.address().port}/`)
-  })
-
-  await instance.listen({ port: 0 })
-
-  const { statusCode } = await got.get(`http://localhost:${instance.server.address().port}/`, { retry: 0 })
-  t.equal(statusCode, 200)
-})
-
 test('http2 session timeout', async (t) => {
   const target = Fastify({ http2: true, sessionTimeout: 0 })
   t.teardown(target.close.bind(target))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Related to #298. It was mentioned there `undici` possibly has a bug regarding this. I will work on creating a small reproduction and create an issue on that module

This checks the response headers for `content-type: text/event-stream`, and if found, get rid of any existing timeouts.

Fixes #298

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
