### PR TITLE
fix proxying with double slash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,6 +57,11 @@ function stripHttp1ConnectionHeaders (headers) {
 // issue ref: https://github.com/fastify/fast-proxy/issues/42
 function buildURL (source, reqBase) {
   let baseOrigin = reqBase ? new URL(reqBase).href : undefined
+
+  // To make sure we don't accidentally override the base path
+  if (baseOrigin && source.startsWith('//')) {
+    source = '.' + source
+  }
   const dest = new URL(source, reqBase)
 
   // if base is specified, source url should not override it

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,7 +59,7 @@ function buildURL (source, reqBase) {
   let baseOrigin = reqBase ? new URL(reqBase).href : undefined
 
   // To make sure we don't accidentally override the base path
-  if (baseOrigin && source.startsWith('//')) {
+  if (baseOrigin && source[0] === '/' && source[1] === '/') {
     source = '.' + source
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,7 +59,7 @@ function buildURL (source, reqBase) {
   let baseOrigin = reqBase ? new URL(reqBase).href : undefined
 
   // To make sure we don't accidentally override the base path
-  if (baseOrigin && source[0] === '/' && source[1] === '/') {
+  if (baseOrigin && source.length > 1 && source[0] === '/' && source[1] === '/') {
     source = '.' + source
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,6 +62,7 @@ function buildURL (source, reqBase) {
   if (baseOrigin && source.startsWith('//')) {
     source = '.' + source
   }
+
   const dest = new URL(source, reqBase)
 
   // if base is specified, source url should not override it

--- a/test/build-url.test.js
+++ b/test/build-url.test.js
@@ -42,12 +42,19 @@ test('should handle default port in base', (t) => {
   t.equal(url.href, 'https://localhost/hi')
 })
 
+test('should append instead of override base', (t) => {
+  t.plan(2)
+  let url = buildURL('//10.0.0.10/hi', 'http://localhost')
+  t.equal(url.href, 'http://localhost//10.0.0.10/hi')
+
+  url = buildURL('//httpbin.org/hi', 'http://localhost')
+  t.equal(url.href, 'http://localhost//httpbin.org/hi')
+})
+
 const errorInputs = [
-  { source: '//10.0.0.10/hi', base: 'http://localhost' },
   { source: 'http://10.0.0.10/hi', base: 'http://localhost' },
   { source: 'https://10.0.0.10/hi', base: 'http://localhost' },
   { source: 'blah://10.0.0.10/hi', base: 'http://localhost' },
-  { source: '//httpbin.org/hi', base: 'http://localhost' },
   { source: 'urn:foo:bar', base: 'http://localhost' },
   { source: 'http://localhost/private', base: 'http://localhost/exposed/' },
   { source: 'http://localhost/exposed-extra', base: 'http://localhost/exposed' },


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fix:
- fastify/fastify-http-proxy#307
