### PR TITLE
feat: add `method` opt to overwrite http method

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,10 @@ through `JSON.stringify()`.
 Setting this option for GET, HEAD requests will throw an error "Rewriting the body when doing a {GET|HEAD} is not allowed".
 Setting this option to `null` will strip the body (and `content-type` header) entirely from the proxied request.
 
+#### `method`
+
+Replaces the original request method with what is specified. 
+
 #### `retriesCount`
 
 How many times it will try to pick another connection on socket hangup (`ECONNRESET` error).  

--- a/test/method.test.js
+++ b/test/method.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+
+t.plan(9)
+t.teardown(instance.close.bind(instance))
+
+const bodyString = JSON.stringify({ hello: 'world' })
+
+const parsedLength = Buffer.byteLength(bodyString)
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'POST')
+  t.equal(req.headers['content-type'], 'application/json')
+  t.same(req.headers['content-length'], parsedLength)
+  let data = ''
+  req.setEncoding('utf8')
+  req.on('data', (d) => {
+    data += d
+  })
+  req.on('end', () => {
+    t.same(JSON.parse(data), { hello: 'world' })
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ something: 'else' }))
+  })
+})
+
+instance.patch('/', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}`, { method: 'POST' })
+})
+
+t.teardown(target.close.bind(target))
+
+target.listen({ port: 0 }, (err) => {
+  t.error(err)
+
+  instance.addContentTypeParser('application/json', function (req, payload, done) {
+    done(null, payload)
+  })
+
+  instance.register(From, {
+    base: `http://localhost:${target.address().port}`,
+    undici: true
+  })
+
+  instance.listen({ port: 0 }, (err) => {
+    t.error(err)
+
+    get({
+      url: `http://localhost:${instance.server.address().port}`,
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: bodyString
+    }, (err, res, data) => {
+      t.error(err)
+      const parsed = JSON.parse(data)
+      t.same(parsed, { something: 'else' })
+    })
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -67,6 +67,7 @@ declare namespace fastifyReplyFrom {
       request: FastifyRequest<RequestGenericInterface, RawServerBase>,
       base: string
     ) => string;
+    method?: HTTPMethods;
   }
 
   interface Http2Options {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -90,6 +90,7 @@ async function main() {
 
   instance.get("/http2", (request, reply) => {
       reply.from("/", {
+          method: "POST",
           rewriteHeaders(headers, req) {
               return headers;
           },


### PR DESCRIPTION
adds a `method` opt to overwrite the http method of the request that is being sent to the target. 

use case is that the target may only support a `POST` request, for example because it does not confirm to certain standards, but the proxy should expose the same endpoint as `PATCH`. with the `method` parameter set to `POST`, the incoming `PATCH` request is forwarded as `POST`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
