### PR TITLE
[feature] custom retry callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ npm i @fastify/reply-from
 ```
 
 ## Compatibility with @fastify/multipart
-`@fastify/reply-from` and [`@fastify/multipart`](https://github.com/fastify/fastify-multipart) should not be registered as sibling plugins nor should they be registered in plugins which have a parent-child relationship.<br> The two plugins are incompatible, in the sense that the behavior of `@fastify/reply-from` might not be the expected one when the above-mentioned conditions are not respected.<br> This is due to the fact that `@fastify/multipart` consumes the multipart content by parsing it, hence this content is not forwarded to the target service by `@fastify/reply-from`.<br>
+
+`@fastify/reply-from` and [`@fastify/multipart`](https://github.com/fastify/fastify-multipart) should not be registered as sibling plugins nor should they be registered in plugins which have a parent-child relationship.`<br>` The two plugins are incompatible, in the sense that the behavior of `@fastify/reply-from` might not be the expected one when the above-mentioned conditions are not respected.`<br>` This is due to the fact that `@fastify/multipart` consumes the multipart content by parsing it, hence this content is not forwarded to the target service by `@fastify/reply-from`.`<br>`
 However, the two plugins may be used within the same fastify instance, at the condition that they belong to disjoint branches of the fastify plugins hierarchy tree.
 
 ## Usage
@@ -102,6 +103,7 @@ proxy.register(require('@fastify/reply-from'), {
   }
 })
 ```
+
 See undici own options for more configurations.
 
 You can also pass the plugin a custom instance:
@@ -136,6 +138,7 @@ proxy.register(require('@fastify/reply-from'), {
 ```
 
 You can also pass custom HTTP agents. If you pass the agents, then the http.agentOptions will be ignored. To illustrate:
+
 ```js
 proxy.register(require('@fastify/reply-from'), {
   base: 'http://localhost:3001/',
@@ -221,6 +224,7 @@ This plugin will always retry on 503 errors, _unless_ `retryMethods` does not co
 Enables the possibility to explictly opt-in for global agents.
 
 Usage for undici global agent:
+
 ```js
 import { setGlobalDispatcher, ProxyAgent } from 'undici'
 
@@ -234,6 +238,7 @@ fastify.register(FastifyReplyFrom, {
 ```
 
 Usage for http/https global agent:
+
 ```js
 fastify.register(FastifyReplyFrom, {
   base: 'http://localhost:3001/',
@@ -263,22 +268,23 @@ This option set the limit on how many times the plugin should retry the request,
 
 By Default: 10
 
-
 ---
+
 ### `customRetry`
-  - `handler`. Required
-  - `retries`. Optional
+
+- `handler`. Required
+- `retries`. Optional
 
 This plugin gives the client an option to pass their own retry callback to handle retries on their own.
 If a `handler` is passed to the `customRetry` object the onus is on the client to invoke the default retry logic in their callback otherwise default cases such as 503 will not be handled
 
 Given example
+
 ```js
-  const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
+  const customRetryLogic = (req, res, getDefaultRetry) => {
     //If this block is not included all non 500 errors will not be retried
-    if (registerDefaultRetry()){
-      return defaultRetryAfter;
-    }
+    const defaultDelay = getDefaultDelay();
+    if (defaultDelay) return defaultDelay();
 
     //Custom retry logic
     if (res && res.statusCode === 500 && req.method === 'GET') {
@@ -295,6 +301,7 @@ fastify.register(FastifyReplyFrom, {
 })
 
 ```
+
 ---
 
 ### `reply.from(source, [opts])`
@@ -359,6 +366,7 @@ ContraintStrategies.
 e.g.:
 
 Route grpc-web/http1 and grpc/http2 to different routes with a ContentType-ConstraintStrategy:
+
 ```
 const contentTypeMatchContraintStrategy = {
     // strategy name for referencing in the route handler `constraints` options
@@ -383,6 +391,7 @@ const contentTypeMatchContraintStrategy = {
 ```
 
 and then 2 different upstreams with different register's:
+
 ```
 // grpc-web / http1
 server.register(fastifyHttpProxy, {
@@ -400,7 +409,6 @@ server.register(fastifyHttpProxy, {
     constraints: { "contentType": "application/grpc+proto" }
 });
 ```
-
 
 #### `queryString` or `queryString(search, reqUrl)`
 
@@ -441,10 +449,10 @@ already overriding the [`body`](#body).
 `formbody` expects the body to be returned as a string and not an object.
 Use the [`contentTypesToEncode`](#contentTypesToEncode) option to pass in `['application/x-www-form-urlencoded']`
 
-
 ### HTTP & HTTP2 timeouts
 
 This library has:
+
 - `timeout` for `http` set by default. The default value is 10 seconds (`10000`).
 - `requestTimeout` & `sessionTimeout` for `http2` set by default.
   - The default value for `requestTimeout` is 10 seconds (`10000`).
@@ -457,10 +465,10 @@ will be returned to the client.
 
 * [ ] support overriding the body with a stream
 * [ ] forward the request id to the other peer might require some
-      refactoring because we have to make the `req.id` unique
-      (see [hyperid](https://npm.im/hyperid)).
+  refactoring because we have to make the `req.id` unique
+  (see [hyperid](https://npm.im/hyperid)).
 * [ ] Support origin HTTP2 push
-* [x] benchmarks
+* [X] benchmarks
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ proxy.register(require('@fastify/reply-from'), {
 
 #### `http`
 
-Set the `http` option to an Object to use 
+Set the `http` option to an Object to use
 Node's [`http.request`](https://nodejs.org/api/http.html#http_http_request_options_callback)
 will be used if you do not enable [`http2`](#http2). To customize the `request`,
 you can pass in [`agentOptions`](https://nodejs.org/api/http.html#http_new_agent_options) and
@@ -192,27 +192,27 @@ The number of parsed URLs that will be cached. Default: `100`.
 
 #### `disableCache`
 
-This option will disable the URL caching. 
+This option will disable the URL caching.
 This cache is dedicated to reduce the amount of URL object generation.
 Generating URLs is a main bottleneck of this module, please disable this cache with caution.
 
 #### `contentTypesToEncode`
 
-An array of content types whose response body will be passed through `JSON.stringify()`. 
+An array of content types whose response body will be passed through `JSON.stringify()`.
 This only applies when a custom [`body`](#body) is not passed in. Defaults to:
 
 ```js
-[ 
+[
   'application/json'
 ]
 ```
 
 #### `retryMethods`
 
-On which methods should the connection be retried in case of socket hang up.  
+On which methods should the connection be retried in case of socket hang up.
 **Be aware** that setting here not idempotent method may lead to unexpected results on target.
 
-By default: `['GET', 'HEAD', 'OPTIONS', 'TRACE' ]`
+By default: `['GET', 'HEAD', 'OPTIONS', 'TRACE', 'POST', 'PATCH']`
 
 This plugin will always retry on 503 errors, _unless_ `retryMethods` does not contain `GET`.
 
@@ -238,7 +238,7 @@ Usage for http/https global agent:
 fastify.register(FastifyReplyFrom, {
   base: 'http://localhost:3001/',
   // http and https is allowed to use http.globalAgent or https.globalAgent
-  globalAgent: true, 
+  globalAgent: true,
   http: {
   }
 })
@@ -264,6 +264,37 @@ This option set the limit on how many times the plugin should retry the request,
 By Default: 10
 
 
+---
+### `customRetry`
+  - `handler`. Required
+  - `retries`. Optional
+
+This plugin gives the client an option to pass their own retry callback to handle retries on their own.
+If a `handler` is passed to the `customRetry` object the onus is on the client to invoke the default retry logic in their callback otherwise default cases such as 503 will not be handled
+
+Given example
+```js
+  const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
+    //If this block is not included all non 500 errors will not be retried
+    if (registerDefaultRetry()){
+      return defaultRetryAfter;
+    }
+
+    //Custom retry logic
+    if (res && res.statusCode === 500 && req.method === 'GET') {
+      return 300
+    }
+    return null
+  }
+
+.......
+
+fastify.register(FastifyReplyFrom, {
+  base: 'http://localhost:3001/',
+  customRetry: {handler: customRetryLogic, retries: 10}
+})
+
+```
 ---
 
 ### `reply.from(source, [opts])`
@@ -341,13 +372,13 @@ const contentTypeMatchContraintStrategy = {
       }
     },
     // function to get the value of the constraint from each incoming request
-    deriveConstraint: (req: any, ctx: any) => { 
+    deriveConstraint: (req: any, ctx: any) => {
       return req.headers['content-type']
     },
     // optional flag marking if handlers without constraints can match requests that have a value for this constraint
     mustMatchWhenDerived: true
   }
- 
+
   server.addConstraintStrategy(contentTypeMatchContraintStrategy);
 ```
 
@@ -359,14 +390,14 @@ server.register(fastifyHttpProxy, {
     // therefore we have to transport to the grpc-web-proxy via http1
     http2: false,
     upstream: 'http://grpc-web-proxy',
-    constraints: { "contentType": "application/grpc-web+proto" }   
+    constraints: { "contentType": "application/grpc-web+proto" }
 });
 
 // grpc / http2
 server.register(fastifyHttpProxy, {
     http2: true,
     upstream: 'http://grpc.server',
-    constraints: { "contentType": "application/grpc+proto" }   
+    constraints: { "contentType": "application/grpc+proto" }
 });
 ```
 
@@ -390,12 +421,12 @@ Setting this option to `null` will strip the body (and `content-type` header) en
 
 #### `method`
 
-Replaces the original request method with what is specified. 
+Replaces the original request method with what is specified.
 
 #### `retriesCount`
 
-How many times it will try to pick another connection on socket hangup (`ECONNRESET` error).  
-Useful when keeping the connection open (KeepAlive).  
+How many times it will try to pick another connection on socket hangup (`ECONNRESET` error).
+Useful when keeping the connection open (KeepAlive).
 This number should be a function of the number of connections and the number of instances of a target.
 
 By default: 0 (disabled)
@@ -407,7 +438,7 @@ already overriding the [`body`](#body).
 
 ### Combining with [@fastify/formbody](https://github.com/fastify/fastify-formbody)
 
-`formbody` expects the body to be returned as a string and not an object. 
+`formbody` expects the body to be returned as a string and not an object.
 Use the [`contentTypesToEncode`](#contentTypesToEncode) option to pass in `['application/x-www-form-urlencoded']`
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ npm i @fastify/reply-from
 ```
 
 ## Compatibility with @fastify/multipart
-
 `@fastify/reply-from` and [`@fastify/multipart`](https://github.com/fastify/fastify-multipart) should not be registered as sibling plugins nor should they be registered in plugins which have a parent-child relationship.`<br>` The two plugins are incompatible, in the sense that the behavior of `@fastify/reply-from` might not be the expected one when the above-mentioned conditions are not respected.`<br>` This is due to the fact that `@fastify/multipart` consumes the multipart content by parsing it, hence this content is not forwarded to the target service by `@fastify/reply-from`.`<br>`
 However, the two plugins may be used within the same fastify instance, at the condition that they belong to disjoint branches of the fastify plugins hierarchy tree.
 
@@ -103,7 +102,6 @@ proxy.register(require('@fastify/reply-from'), {
   }
 })
 ```
-
 See undici own options for more configurations.
 
 You can also pass the plugin a custom instance:
@@ -215,7 +213,7 @@ This only applies when a custom [`body`](#body) is not passed in. Defaults to:
 On which methods should the connection be retried in case of socket hang up.
 **Be aware** that setting here not idempotent method may lead to unexpected results on target.
 
-By default: `['GET', 'HEAD', 'OPTIONS', 'TRACE', 'POST', 'PATCH']`
+By default: `['GET', 'HEAD', 'OPTIONS', 'TRACE']`
 
 This plugin will always retry on 503 errors, _unless_ `retryMethods` does not contain `GET`.
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const {
 } = require('./lib/errors')
 const { warn } = require('node:console')
 
-const fastifyReplyFrom = fp(function from(fastify, opts, next) {
+const fastifyReplyFrom = fp(function from (fastify, opts, next) {
   const contentTypesToEncode = new Set([
     'application/json',
     ...(opts.contentTypesToEncode || [])
@@ -144,9 +144,7 @@ const fastifyReplyFrom = fp(function from(fastify, opts, next) {
     const contentLength = requestHeaders['content-length']
     let requestImpl
     if (retryMethods.has(method) && !contentLength) {
-
       const retryHandler = (req, res, err, retries) => {
-
         const defaultDelay = () => {
           // Magic number, so why not 42? We might want to make this configurable.
           let retryAfter = 42 * Math.random() * (retries + 1)
@@ -165,10 +163,11 @@ const fastifyReplyFrom = fp(function from(fastify, opts, next) {
           return null
         }
 
-        if (customRetry && customRetry.handler){
+        if (customRetry && customRetry.handler) {
           const customRetries = customRetry.retries || 1
           if (++retries < customRetries) {
-            return customRetry.handler(req, res, defaultDelay)}
+            return customRetry.handler(req, res, defaultDelay)
+          }
         }
         return defaultDelay()
       }
@@ -237,7 +236,7 @@ const fastifyReplyFrom = fp(function from(fastify, opts, next) {
   name: '@fastify/reply-from'
 })
 
-function getQueryString(search, reqUrl, opts) {
+function getQueryString (search, reqUrl, opts) {
   if (typeof opts.queryString === 'function') {
     return '?' + opts.queryString(search, reqUrl)
   }
@@ -259,33 +258,33 @@ function getQueryString(search, reqUrl, opts) {
   return ''
 }
 
-function headersNoOp(headers, originalReq) {
+function headersNoOp (headers, originalReq) {
   return headers
 }
 
-function requestHeadersNoOp(originalReq, headers) {
+function requestHeadersNoOp (originalReq, headers) {
   return headers
 }
 
-function upstreamNoOp(req, base) {
+function upstreamNoOp (req, base) {
   return base
 }
 
-function onErrorDefault(reply, { error }) {
+function onErrorDefault (reply, { error }) {
   reply.send(error)
 }
 
-function isFastifyMultipartRegistered(fastify) {
+function isFastifyMultipartRegistered (fastify) {
   // TODO: remove fastify.hasContentTypeParser('multipart') in next major
   // It is used to be compatible with @fastify/multipart@<=7.3.0
   return (fastify.hasContentTypeParser('multipart') || fastify.hasContentTypeParser('multipart/form-data')) && fastify.hasRequestDecorator('multipart')
 }
 
-function createRequestRetry(requestImpl, reply, retryHandler) {
-  function requestRetry(req, cb) {
+function createRequestRetry (requestImpl, reply, retryHandler) {
+  function requestRetry (req, cb) {
     let retries = 0
 
-    function run() {
+    function run () {
       requestImpl(req, function (err, res) {
         const retryDelay = retryHandler(req, res, err, retries)
         if (!reply.sent && retryDelay) {
@@ -295,7 +294,7 @@ function createRequestRetry(requestImpl, reply, retryHandler) {
       })
     }
 
-    function retry(after) {
+    function retry (after) {
       retries += 1
       setTimeout(run, after)
     }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ const {
   UndiciSocketError,
   InternalServerError
 } = require('./lib/errors')
-const { warn } = require('node:console')
 
 const fastifyReplyFrom = fp(function from (fastify, opts, next) {
   const contentTypesToEncode = new Set([

--- a/test/retry-with-a-custom-handler.test.js
+++ b/test/retry-with-a-custom-handler.test.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('node:http')
+const got = require('got')
+
+function serverWithCustomError (stopAfter, statusCodeToFailOn) {
+  let requestCount = 0
+  return http.createServer((req, res) => {
+    if (requestCount++ < stopAfter) {
+      res.statusCode = statusCodeToFailOn
+      res.setHeader('Content-Type', 'text/plain')
+      return res.end('This Service is Unavailable')
+    } else {
+      res.statusCode = 205
+      res.setHeader('Content-Type', 'text/plain')
+      return res.end(`Hello World ${requestCount}!`)
+    }
+  })
+}
+
+async function setupServer (t, fromOptions = {}, statusCodeToFailOn = 500, stopAfter = 4) {
+  const target = serverWithCustomError(stopAfter, statusCodeToFailOn)
+  await target.listen({ port: 0 })
+  t.teardown(target.close.bind(target))
+
+  const instance = Fastify()
+  instance.register(From, {
+    base: `http://localhost:${target.address().port}`
+  })
+
+  instance.get('/', (request, reply) => {
+    reply.from(`http://localhost:${target.address().port}`, fromOptions)
+  })
+
+  t.teardown(instance.close.bind(instance))
+  await instance.listen({ port: 0 })
+
+  return {
+    instance
+  }
+}
+
+test('a 500 status code with no custom handler should fail', async (t) => {
+  const { instance } = await setupServer(t)
+
+  try {
+    await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
+  } catch (error) {
+    t.ok(error instanceof got.RequestError, 'should throw RequestError')
+    t.end()
+  }
+})
+
+test("a server 500's with a custom handler and should revive", async (t) => {
+  const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
+    if (res && res.statusCode === 500 && req.method === 'GET') {
+      return 300
+    }
+    return null
+  }
+
+  const { instance } = await setupServer(t, { customRetry: { handler: customRetryLogic, retries: 10 } })
+
+  const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
+
+  t.equal(res.headers['content-type'], 'text/plain')
+  t.equal(res.statusCode, 205)
+  t.equal(res.body.toString(), 'Hello World 5!')
+})
+
+test("a server 503's with a custom handler for 500 but the custom handler never registers the default so should fail", async (t) => {
+  // the key here is our customRetryHandler doesn't register the deefault handler and as a result it doesn't work
+  const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
+    if (res && res.statusCode === 500 && req.method === 'GET') {
+      return 300
+    }
+    return null
+  }
+
+  const { instance } = await setupServer(t, { customRetry: { handler: customRetryLogic, retries: 10 } }, 503)
+
+  try {
+    await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
+  } catch (error) {
+    t.equal(error.message, 'Response code 503 (Service Unavailable)')
+    t.end()
+  }
+})
+
+test("a server 503's with a custom handler for 500 and the custom handler registers the default so it passes", async (t) => {
+  const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
+    // registering the default retry logic for non 500 errors if it occurs
+    if (registerDefaultRetry()) {
+      return defaultRetryAfter
+    }
+
+    if (res && res.statusCode === 500 && req.method === 'GET') {
+      return 300
+    }
+
+    return null
+  }
+
+  const { instance } = await setupServer(t, { customRetry: { handler: customRetryLogic, retries: 10 } }, 503)
+
+  const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
+
+  t.equal(res.headers['content-type'], 'text/plain')
+  t.equal(res.statusCode, 205)
+  t.equal(res.body.toString(), 'Hello World 6!')
+})

--- a/test/retry-with-a-custom-handler.test.js
+++ b/test/retry-with-a-custom-handler.test.js
@@ -6,7 +6,7 @@ const From = require('..')
 const http = require('node:http')
 const got = require('got')
 
-function serverWithCustomError(stopAfter, statusCodeToFailOn) {
+function serverWithCustomError (stopAfter, statusCodeToFailOn) {
   let requestCount = 0
   return http.createServer((req, res) => {
     if (requestCount++ < stopAfter) {
@@ -21,7 +21,7 @@ function serverWithCustomError(stopAfter, statusCodeToFailOn) {
   })
 }
 
-async function setupServer(t, fromOptions = {}, statusCodeToFailOn = 500, stopAfter = 4) {
+async function setupServer (t, fromOptions = {}, statusCodeToFailOn = 500, stopAfter = 4) {
   const target = serverWithCustomError(stopAfter, statusCodeToFailOn)
   await target.listen({ port: 0 })
   t.teardown(target.close.bind(target))
@@ -59,7 +59,7 @@ test('a 500 status code with no custom handler should fail', async (t) => {
 test("a server 500's with a custom handler and should revive", async (t) => {
   const customRetryLogic = (req, res, getDefaultDelay) => {
     const defaultDelay = getDefaultDelay()
-    if (defaultDelay) return defaultDelay;
+    if (defaultDelay) return defaultDelay
 
     if (res && res.statusCode === 500 && req.method === 'GET') {
       return 300
@@ -76,7 +76,7 @@ test("a server 500's with a custom handler and should revive", async (t) => {
   t.equal(res.body.toString(), 'Hello World 5!')
 })
 
-test("custom retry does not invoke the default delay causing a 503", async (t) => {
+test('custom retry does not invoke the default delay causing a 503', async (t) => {
   // the key here is our customRetryHandler doesn't register the deefault handler and as a result it doesn't work
   const customRetryLogic = (req, res, getDefaultDelay) => {
     if (res && res.statusCode === 500 && req.method === 'GET') {
@@ -97,11 +97,11 @@ test("custom retry does not invoke the default delay causing a 503", async (t) =
   t.equal(errorMessage, 'Response code 503 (Service Unavailable)')
 })
 
-test("custom retry delay functions can invoke the default delay", async (t) => {
+test('custom retry delay functions can invoke the default delay', async (t) => {
   const customRetryLogic = (req, res, getDefaultDelay) => {
     // registering the default retry logic for non 500 errors if it occurs
     const defaultDelay = getDefaultDelay()
-    if (defaultDelay) return defaultDelay;
+    if (defaultDelay) return defaultDelay
 
     if (res && res.statusCode === 500 && req.method === 'GET') {
       return 300

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,12 +1,12 @@
-import replyFrom, { FastifyReplyFromOptions } from "..";
-import fastify, {FastifyReply, FastifyRequest, RawServerBase, RequestGenericInterface} from "fastify";
-import { AddressInfo } from "net";
-import { IncomingHttpHeaders } from "http2";
-import { expectType } from 'tsd';
+import fastify, { FastifyReply, FastifyRequest, RawServerBase, RequestGenericInterface } from "fastify";
 import * as http from 'http';
+import { IncomingHttpHeaders } from "http2";
 import * as https from 'https';
+import { AddressInfo } from "net";
+import { expectType } from 'tsd';
+import replyFrom, { FastifyReplyFromOptions } from "..";
 // @ts-ignore
-import tap from 'tap'
+import tap from 'tap';
 
 const fullOptions: FastifyReplyFromOptions = {
   base: "http://example2.com",
@@ -41,7 +41,7 @@ const fullOptions: FastifyReplyFromOptions = {
     pipelining: 10
   },
   contentTypesToEncode: ['application/x-www-form-urlencoded'],
-  retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
+  retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE', 'POST', 'PATCH'],
   maxRetriesOn503: 10,
   disableRequestLogging: false,
   globalAgent: false,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -41,7 +41,7 @@ const fullOptions: FastifyReplyFromOptions = {
     pipelining: 10
   },
   contentTypesToEncode: ['application/x-www-form-urlencoded'],
-  retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE', 'POST', 'PATCH'],
+  retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
   maxRetriesOn503: 10,
   disableRequestLogging: false,
   globalAgent: false,


### PR DESCRIPTION
# This PR implements two fundamental changes.
Edit: ~~1. I have added `PATCH` and `POST` as given default `retryMethods`~~ see review by airhorns
2. I have added the option to pass a callback to handle retries in a custom fashion as defined by the client.

## Point 2. Described
The motivation for this change is that out of the box `reply-from` does not retry 500's so gracefully handling such cases is not possible. As a result with this change you are able to write your own callback to retry 500's as you wish (or any other kind of error - using 500's here as an exemplar).

This can be done quite simply.
 ```
 const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
    if (res && res.statusCode === 500 && req.method === 'GET') {
      return 300
    }
    return null
  }

...
Fastify.reply(From, customRetry: { handler: customRetryLogic, retries: 10 }}
```


Note this new API is an object which has two keys. `handler` and `retries` where handler is a required key and retries is optional but strongly encouraged.

-----
### There is an important intricacy to this API.
If no `customRetry` object is passed then business as usual in the library. Retries work as they are expected for default cases.

But if a `customRetry` is passed then it is up to responsibility of the callback to be aware that if they expect default behaviour to co-exist they must register it. If they don't (the above example DID NOT) all default cases of errors (such as 503s) won't be retried.

Example to get default behaviour in a `customRetry`

 ```
 const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
    // Registering the default retry logic so if a default case occurs we handle it.
    if (registerDefaultRetry()){
      return defaultRetryAfter; // Some new magic is that we can override our headers and pass a new retry-after value.
    }

    if (res && res.statusCode === 500 && req.method === 'GET') {
      return 300
    }
    return null
  }
```

CC: @airhorns 

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
