### PR TITLE
add: error object to custom retry callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,18 +268,25 @@ By Default: 10
 
 ---
 
-### `customRetry`
+### `retryDelay`
 
 - `handler`. Required
-- `retries`. Optional
 
-This plugin gives the client an option to pass their own retry callback to handle retries on their own.
-If a `handler` is passed to the `customRetry` object the onus is on the client to invoke the default retry logic in their callback otherwise default cases such as 503 will not be handled
+This plugin gives the client an option to pass their own retry callback to allow the client to define what retryDelay they would like on any retries
+outside the scope of what is handled by default in fastify-reply-from. To see the default please refer to index.js `getDefaultDelay()`
+If a `handler` is passed to the `retryDelay` object the onus is on the client to invoke the default retry logic in their callback otherwise default cases such as 500 will not be handled
+
+- The `attempt` property in the object callback refers to the current retriesAttempt number.
+You are given the freedom to use this in concert with the retryCount property set to handle retries
+
+- `getDefaultRetry` refers to the default retry handler. If this callback returns not null and you wish to handle those case of errors simply invoke it as done below.
+
+- `err`, `req`, `res` are self-explanatory error, request, and response properties respectively
 
 Given example
 
 ```js
-   const customRetryLogic = ({req, res, err, getDefaultRetry}) => {
+   const customRetryLogic = ({err, req, res, attempt, getDefaultRetry}) => {
     //If this block is not included all non 500 errors will not be retried
     const defaultDelay = getDefaultDelay();
     if (defaultDelay) return defaultDelay();
@@ -300,7 +307,7 @@ Given example
 
 fastify.register(FastifyReplyFrom, {
   base: 'http://localhost:3001/',
-  customRetry: {handler: customRetryLogic, retries: 10}
+  customRetry: {handler: customRetryLogic}
 })
 
 ```

--- a/README.md
+++ b/README.md
@@ -276,12 +276,11 @@ This plugin gives the client an option to pass their own retry callback to allow
 outside the scope of what is handled by default in fastify-reply-from. To see the default please refer to index.js `getDefaultDelay()`
 If a `handler` is passed to the `retryDelay` object the onus is on the client to invoke the default retry logic in their callback otherwise default cases such as 500 will not be handled
 
-- The `attempt` property in the object callback refers to the current retriesAttempt number.
-You are given the freedom to use this in concert with the retryCount property set to handle retries
-
+- `err` is the error thrown by making a request using whichever agent is configured
+- `req` is the raw request details sent to the underlying agent. __Note__: this object is not a Fastify request object, but instead the low-level request for the agent.
+- `res` is the raw response returned by the underlying agent (if available) __Note__: this object is not a Fastify response, but instead the low-level response from the agent. This property may be null if no response was obtained at all, like from a connection reset or timeout.
+- `attempt` in the object callback refers to the current retriesAttempt number. You are given the freedom to use this in concert with the retryCount property set to handle retries
 - `getDefaultRetry` refers to the default retry handler. If this callback returns not null and you wish to handle those case of errors simply invoke it as done below.
-
-- `err`, `req`, `res` are self-explanatory error, request, and response properties respectively
 
 Given example
 
@@ -307,7 +306,7 @@ Given example
 
 fastify.register(FastifyReplyFrom, {
   base: 'http://localhost:3001/',
-  customRetry: {handler: customRetryLogic}
+  retryDelay: customRetryLogic
 })
 
 ```

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ If a `handler` is passed to the `customRetry` object the onus is on the client t
 Given example
 
 ```js
-   const customRetryLogic = (req, res, err, getDefaultRetry) => {
+   const customRetryLogic = ({req, res, err, getDefaultRetry}) => {
     //If this block is not included all non 500 errors will not be retried
     const defaultDelay = getDefaultDelay();
     if (defaultDelay) return defaultDelay();
@@ -305,6 +305,14 @@ fastify.register(FastifyReplyFrom, {
 
 ```
 
+Note the Typescript Equivalent
+```
+const customRetryLogic = ({req, res, err, getDefaultRetry}: customRetryHandler) => {
+  ...
+}
+...
+
+```
 ---
 
 ### `reply.from(source, [opts])`

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ If a `handler` is passed to the `customRetry` object the onus is on the client t
 Given example
 
 ```js
-   const customRetryLogic = (req, res, getDefaultRetry, err) => {
+   const customRetryLogic = (req, res, err, getDefaultRetry) => {
     //If this block is not included all non 500 errors will not be retried
     const defaultDelay = getDefaultDelay();
     if (defaultDelay) return defaultDelay();

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ If a `handler` is passed to the `customRetry` object the onus is on the client t
 Given example
 
 ```js
-  const customRetryLogic = (req, res, getDefaultRetry) => {
+   const customRetryLogic = (req, res, getDefaultRetry, err) => {
     //If this block is not included all non 500 errors will not be retried
     const defaultDelay = getDefaultDelay();
     if (defaultDelay) return defaultDelay();
@@ -288,6 +288,11 @@ Given example
     if (res && res.statusCode === 500 && req.method === 'GET') {
       return 300
     }
+
+    if (err && err.code == "UND_ERR_SOCKET"){
+      return 600
+    }
+
     return null
   }
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ fastify.register(FastifyReplyFrom, {
 
 Note the Typescript Equivalent
 ```
-const customRetryLogic = ({req, res, err, getDefaultRetry}: customRetryHandler) => {
+const customRetryLogic = ({req, res, err, getDefaultRetry}: RetryDetails) => {
   ...
 }
 ...

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
         if (customRetry && customRetry.handler) {
           const customRetries = customRetry.retries || 1
           if (++retries < customRetries) {
-            return customRetry.handler(req, res, defaultDelay, err)
+            return customRetry.handler(req, res, err, defaultDelay)
           }
         }
         return defaultDelay()

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
         if (customRetry && customRetry.handler) {
           const customRetries = customRetry.retries || 1
           if (++retries < customRetries) {
-            return customRetry.handler(req, res, defaultDelay)
+            return customRetry.handler(req, res, defaultDelay, err)
           }
         }
         return defaultDelay()

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
     let requestImpl
     if (retryMethods.has(method) && !contentLength) {
       const retryHandler = (req, res, err, retries) => {
-        const defaultDelay = () => {
+        const getDefaultDelay = () => {
           // Magic number, so why not 42? We might want to make this configurable.
           let retryAfter = 42 * Math.random() * (retries + 1)
 
@@ -165,10 +165,10 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
         if (customRetry && customRetry.handler) {
           const customRetries = customRetry.retries || 1
           if (++retries < customRetries) {
-            return customRetry.handler(req, res, err, defaultDelay)
+            return customRetry.handler({err, req, res, getDefaultDelay})
           }
         }
-        return defaultDelay()
+        return getDefaultDelay()
       }
 
       requestImpl = createRequestRetry(request, this, retryHandler)

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
         if (customRetry && customRetry.handler) {
           const customRetries = customRetry.retries || 1
           if (++retries < customRetries) {
-            return customRetry.handler({err, req, res, getDefaultDelay})
+            return customRetry.handler({ err, req, res, getDefaultDelay })
           }
         }
         return getDefaultDelay()

--- a/index.js
+++ b/index.js
@@ -162,14 +162,12 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
       return null
     }
 
-    if (retryDelay && retryDelay.handler) {
+    if (retryDelay) {
       requestImpl = createRequestRetry(request, this, (req, res, err, retries) => {
-        return retryDelay.handler({ err, req, res, attempt: retries, getDefaultDelay })
+        return retryDelay({ err, req, res, attempt: retries, getDefaultDelay })
       })
-    } else if (retryMethods.has(method) && !contentLength) {
-      requestImpl = createRequestRetry(request, this, getDefaultDelay)
     } else {
-      requestImpl = request
+      requestImpl = createRequestRetry(request, this, getDefaultDelay)
     }
 
     requestImpl({ method, url, qs, headers: requestHeaders, body }, (err, res) => {

--- a/test/retry-with-a-custom-handler.test.js
+++ b/test/retry-with-a-custom-handler.test.js
@@ -138,8 +138,8 @@ test('custom retry delay function inspects the err paramater', async (t) => {
   t.equal(res.body.toString(), 'Hello World 5!')
 })
 
-test('we can exceed our retryCount and introspect attempts independently', async(t) => {
-  let attemptCounter = []
+test('we can exceed our retryCount and introspect attempts independently', async (t) => {
+  const attemptCounter = []
 
   const customRetryLogic = ({ req, res, err, attempt, getDefaultDelay }) => {
     attemptCounter.push(attempt)
@@ -151,7 +151,7 @@ test('we can exceed our retryCount and introspect attempts independently', async
     return null
   }
 
-  const { instance } = await setupServer(t, { retryDelay: customRetryLogic }, 500, 4, true) //note it takes 8 attempts to work but our retryCount is 5
+  const { instance } = await setupServer(t, { retryDelay: customRetryLogic }, 500, 4, true)
 
   const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 5 })
 
@@ -159,5 +159,4 @@ test('we can exceed our retryCount and introspect attempts independently', async
   t.equal(res.headers['content-type'], 'text/plain')
   t.equal(res.statusCode, 205)
   t.equal(res.body.toString(), 'Hello World 5!')
-
 })

--- a/test/retry-with-a-custom-handler.test.js
+++ b/test/retry-with-a-custom-handler.test.js
@@ -59,7 +59,7 @@ test('a 500 status code with no custom handler should fail', async (t) => {
 })
 
 test("a server 500's with a custom handler and should revive", async (t) => {
-  const customRetryLogic = (req, res, getDefaultDelay) => {
+  const customRetryLogic = (req, res, err, getDefaultDelay) => {
     const defaultDelay = getDefaultDelay()
     if (defaultDelay) return defaultDelay
 
@@ -80,7 +80,7 @@ test("a server 500's with a custom handler and should revive", async (t) => {
 
 test('custom retry does not invoke the default delay causing a 503', async (t) => {
   // the key here is our customRetryHandler doesn't register the deefault handler and as a result it doesn't work
-  const customRetryLogic = (req, res, getDefaultDelay) => {
+  const customRetryLogic = (req, res, err, getDefaultDelay) => {
     if (res && res.statusCode === 500 && req.method === 'GET') {
       return 300
     }
@@ -100,7 +100,7 @@ test('custom retry does not invoke the default delay causing a 503', async (t) =
 })
 
 test('custom retry delay functions can invoke the default delay', async (t) => {
-  const customRetryLogic = (req, res, getDefaultDelay) => {
+  const customRetryLogic = (req, res, err, getDefaultDelay) => {
     // registering the default retry logic for non 500 errors if it occurs
     const defaultDelay = getDefaultDelay()
     if (defaultDelay) return defaultDelay
@@ -122,8 +122,8 @@ test('custom retry delay functions can invoke the default delay', async (t) => {
 })
 
 test('custom retry delay function inspects the err paramater', async (t) => {
-  const customRetryLogic = (req, res, getDefaultDelay, err) => {
-    if (err && (err.code == "UND_ERR_SOCKET" || err.code == "ECONNRESET")){
+  const customRetryLogic = (req, res, err, getDefaultDelay) => {
+    if (err && (err.code === 'UND_ERR_SOCKET' || err.code === 'ECONNRESET')) {
       return 300
     }
     return null

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,14 +46,14 @@ declare namespace fastifyReplyFrom {
     err: Error;
     req: FastifyRequest<RequestGenericInterface, RawServerBase>;
     res: FastifyReply<RawServerBase>;
+    attempt: number;
     getDefaultDelay: () => number | null;
   }
   export interface FastifyReplyFromHooks {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
-    customRetry?: {
+    retryDelay?: {
       handler: (retryObj: customRetryHandler) => {} | null;
-      retries?: number;
     };
     retriesCount?: number;
     onResponse?: (

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,7 +42,7 @@ type FastifyReplyFrom = FastifyPluginCallback<fastifyReplyFrom.FastifyReplyFromO
 declare namespace fastifyReplyFrom {
   type QueryStringFunction = (search: string | undefined, reqUrl: string) => string;
 
-  export type customRetryHandler = {
+  export type RetryDetails = {
     err: Error;
     req: FastifyRequest<RequestGenericInterface, RawServerBase>;
     res: FastifyReply<RawServerBase>;
@@ -52,7 +52,7 @@ declare namespace fastifyReplyFrom {
   export interface FastifyReplyFromHooks {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
-    retryDelay?: (retryObj: customRetryHandler) => {} | null;
+    retryDelay?: (details: RetryDetails) => {} | null;
     retriesCount?: number;
     onResponse?: (
       request: FastifyRequest<RequestGenericInterface, RawServerBase>,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,14 +39,15 @@ declare module "fastify" {
 }
 
 type FastifyReplyFrom = FastifyPluginCallback<fastifyReplyFrom.FastifyReplyFromOptions>
-export type customRetryHandler = {
-  err: Error;
-  req: FastifyRequest<RequestGenericInterface, RawServerBase>;
-  res: FastifyReply<RawServerBase>;
-  getDefaultDelay: () => number | null;
-}
 declare namespace fastifyReplyFrom {
   type QueryStringFunction = (search: string | undefined, reqUrl: string) => string;
+
+  export type customRetryHandler = {
+    err: Error;
+    req: FastifyRequest<RequestGenericInterface, RawServerBase>;
+    res: FastifyReply<RawServerBase>;
+    getDefaultDelay: () => number | null;
+  }
   export interface FastifyReplyFromHooks {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,8 +46,8 @@ declare namespace fastifyReplyFrom {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
     customRetry?: {
-      handler: (request, response, getDefaultDelay) => {},
-      retries: number
+      handler: (request: FastifyRequest<RequestGenericInterface, RawServerBase>, response: FastifyReply<RawServerBase>, getDefaultDelay: () => number | null) => {} | null,
+      retries?: number;
     };
     retriesCount?: number;
     onResponse?: (

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,9 +52,7 @@ declare namespace fastifyReplyFrom {
   export interface FastifyReplyFromHooks {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
-    retryDelay?: {
-      handler: (retryObj: customRetryHandler) => {} | null;
-    };
+    retryDelay?: (retryObj: customRetryHandler) => {} | null;
     retriesCount?: number;
     onResponse?: (
       request: FastifyRequest<RequestGenericInterface, RawServerBase>,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,33 +1,33 @@
 /// <reference types="node" />
 
 import {
-  FastifyRequest,
+  FastifyPluginCallback,
   FastifyReply,
+  FastifyRequest,
+  HTTPMethods,
   RawReplyDefaultExpression,
   RawServerBase,
   RequestGenericInterface,
-  HTTPMethods,
-  FastifyPluginCallback,
 } from 'fastify';
 
 import {
+  Agent,
+  AgentOptions,
   IncomingHttpHeaders,
   RequestOptions,
-  AgentOptions,
-  Agent,
 } from "http";
 import {
-  RequestOptions as SecureRequestOptions,
-  AgentOptions as SecureAgentOptions,
-  Agent as SecureAgent
-} from "https";
-import {
-  IncomingHttpHeaders as Http2IncomingHttpHeaders,
-  ClientSessionRequestOptions,
   ClientSessionOptions,
+  ClientSessionRequestOptions,
+  IncomingHttpHeaders as Http2IncomingHttpHeaders,
   SecureClientSessionOptions,
 } from "http2";
-import { Pool } from 'undici'
+import {
+  Agent as SecureAgent,
+  AgentOptions as SecureAgentOptions,
+  RequestOptions as SecureRequestOptions
+} from "https";
+import { Pool } from 'undici';
 
 declare module "fastify" {
   interface FastifyReply {
@@ -46,7 +46,7 @@ declare namespace fastifyReplyFrom {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
     customRetry?: {
-      handler: (request: FastifyRequest<RequestGenericInterface, RawServerBase>, response: FastifyReply<RawServerBase>, getDefaultDelay: () => number | null) => {} | null,
+      handler: (request: FastifyRequest<RequestGenericInterface, RawServerBase>, response: FastifyReply<RawServerBase>, getDefaultDelay: () => number | null, error: Error) => {} | null,
       retries?: number;
     };
     retriesCount?: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,6 +45,11 @@ declare namespace fastifyReplyFrom {
   export interface FastifyReplyFromHooks {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
+    customRetry?: {
+      handler: (request, response, getDefaultDelay) => {},
+      retries: number
+    };
+    retriesCount?: number;
     onResponse?: (
       request: FastifyRequest<RequestGenericInterface, RawServerBase>,
       reply: FastifyReply<RawServerBase>,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,14 +39,19 @@ declare module "fastify" {
 }
 
 type FastifyReplyFrom = FastifyPluginCallback<fastifyReplyFrom.FastifyReplyFromOptions>
-
+export type customRetryHandler = {
+  err: Error;
+  req: FastifyRequest<RequestGenericInterface, RawServerBase>;
+  res: FastifyReply<RawServerBase>;
+  getDefaultDelay: () => number | null;
+}
 declare namespace fastifyReplyFrom {
   type QueryStringFunction = (search: string | undefined, reqUrl: string) => string;
   export interface FastifyReplyFromHooks {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
     customRetry?: {
-      handler: (request: FastifyRequest<RequestGenericInterface, RawServerBase>, response: FastifyReply<RawServerBase>, error: Error, getDefaultDelay: () => number | null) => {} | null,
+      handler: (retryObj: customRetryHandler) => {} | null;
       retries?: number;
     };
     retriesCount?: number;
@@ -104,7 +109,7 @@ declare namespace fastifyReplyFrom {
   }
 
   export const fastifyReplyFrom: FastifyReplyFrom
-  export { fastifyReplyFrom as default }
+  export { fastifyReplyFrom as default };
 }
 
 declare function fastifyReplyFrom(...params: Parameters<FastifyReplyFrom>): ReturnType<FastifyReplyFrom>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ declare namespace fastifyReplyFrom {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
     customRetry?: {
-      handler: (request: FastifyRequest<RequestGenericInterface, RawServerBase>, response: FastifyReply<RawServerBase>, getDefaultDelay: () => number | null, error: Error) => {} | null,
+      handler: (request: FastifyRequest<RequestGenericInterface, RawServerBase>, response: FastifyReply<RawServerBase>, error: Error, getDefaultDelay: () => number | null) => {} | null,
       retries?: number;
     };
     retriesCount?: number;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -92,7 +92,7 @@ async function main() {
       reply.from("/", {
           method: "POST",
           customRetry: {
-            handler: (req, res, getDefaultDelay) => {
+            handler: (req, res, err, getDefaultDelay) => {
              const defaultDelay = getDefaultDelay();
               if (defaultDelay) return defaultDelay;
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,7 +4,7 @@ import { IncomingHttpHeaders } from "http2";
 import * as https from 'https';
 import { AddressInfo } from "net";
 import { expectType } from 'tsd';
-import replyFrom, { FastifyReplyFromOptions, customRetryHandler } from "..";
+import replyFrom, { FastifyReplyFromOptions } from "..";
 // @ts-ignore
 import tap from 'tap';
 
@@ -91,7 +91,7 @@ async function main() {
   instance.get("/http2", (request, reply) => {
       reply.from("/", {
           method: "POST",
-          retryDelay: ({err, req, res, attempt, getDefaultDelay}: customRetryHandler) => {
+          retryDelay: ({err, req, res, attempt, getDefaultDelay}) => {
               const defaultDelay = getDefaultDelay();
               if (defaultDelay) return defaultDelay;
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -91,8 +91,7 @@ async function main() {
   instance.get("/http2", (request, reply) => {
       reply.from("/", {
           method: "POST",
-          retryDelay: {
-            handler: ({err, req, res, attempt, getDefaultDelay}: customRetryHandler) => {
+          retryDelay: ({err, req, res, attempt, getDefaultDelay}: customRetryHandler) => {
               const defaultDelay = getDefaultDelay();
               if (defaultDelay) return defaultDelay;
 
@@ -101,7 +100,6 @@ async function main() {
               }
               return null;
             },
-          },
           rewriteHeaders(headers, req) {
               return headers;
           },

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,7 +4,7 @@ import { IncomingHttpHeaders } from "http2";
 import * as https from 'https';
 import { AddressInfo } from "net";
 import { expectType } from 'tsd';
-import replyFrom, { FastifyReplyFromOptions } from "..";
+import replyFrom, { FastifyReplyFromOptions, customRetryHandler } from "..";
 // @ts-ignore
 import tap from 'tap';
 
@@ -92,8 +92,8 @@ async function main() {
       reply.from("/", {
           method: "POST",
           customRetry: {
-            handler: (req, res, err, getDefaultDelay) => {
-             const defaultDelay = getDefaultDelay();
+            handler: ({err, req, res, getDefaultDelay}: customRetryHandler) => {
+              const defaultDelay = getDefaultDelay();
               if (defaultDelay) return defaultDelay;
 
               if (res && res.statusCode === 500 && req.method === "GET") {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -91,8 +91,8 @@ async function main() {
   instance.get("/http2", (request, reply) => {
       reply.from("/", {
           method: "POST",
-          customRetry: {
-            handler: ({err, req, res, getDefaultDelay}: customRetryHandler) => {
+          retryDelay: {
+            handler: ({err, req, res, attempt, getDefaultDelay}: customRetryHandler) => {
               const defaultDelay = getDefaultDelay();
               if (defaultDelay) return defaultDelay;
 
@@ -101,7 +101,6 @@ async function main() {
               }
               return null;
             },
-            retries: 3
           },
           rewriteHeaders(headers, req) {
               return headers;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -91,6 +91,18 @@ async function main() {
   instance.get("/http2", (request, reply) => {
       reply.from("/", {
           method: "POST",
+          customRetry: {
+            handler: (req, res, getDefaultDelay) => {
+             const defaultDelay = getDefaultDelay();
+              if (defaultDelay) return defaultDelay;
+
+              if (res && res.statusCode === 500 && req.method === "GET") {
+                return 300;
+              }
+              return null;
+            },
+            retries: 3
+          },
           rewriteHeaders(headers, req) {
               return headers;
           },


### PR DESCRIPTION
This change introduces passing the error object to the custom retry callback; something that should've been done in the initial implementation of this feature but forgotten. Alas this PR introduces passing the error object to the callback.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
