### PR TITLE
add: retriesCount property to the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ If a `handler` is passed to the `retryDelay` object the onus is on the client to
 - `res` is the raw response returned by the underlying agent (if available) __Note__: this object is not a Fastify response, but instead the low-level response from the agent. This property may be null if no response was obtained at all, like from a connection reset or timeout.
 - `attempt` in the object callback refers to the current retriesAttempt number. You are given the freedom to use this in concert with the retryCount property set to handle retries
 - `getDefaultRetry` refers to the default retry handler. If this callback returns not null and you wish to handle those case of errors simply invoke it as done below.
+- `retriesCount` refers to the retriesCount property a client passes to reply-from. Note if the client does not explicitly set this value it will default to 0. The objective value here is to avoid hard-coding and seeing the retriesCount set. It is your perogative to ensure that you ensure the value here is as you wish (and not `0` if not intended to be as a result of a lack of not setting it).
 
 Given example
 

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
 
     if (retryDelay) {
       requestImpl = createRequestRetry(request, this, (req, res, err, retries) => {
-        return retryDelay({ err, req, res, attempt: retries, getDefaultDelay })
+        return retryDelay({ err, req, res, attempt: retries, getDefaultDelay, retriesCount })
       })
     } else {
       requestImpl = createRequestRetry(request, this, getDefaultDelay)


### PR DESCRIPTION
Initially the custom retry handler was put in place to give the client true freedom of handling retries. I quickly saw this comes at a cost of making the simple mistake (which I had done !) of infinitely retrying.

Now there are two approaches to this.
1) Respect the underlying spirit of custom retries and having the client handle the retries (which is what this PR is proposing by passing back the retriesCount).
2) Limiting it on the library and not the client level with a conditional.

I have no belief that one is greater than the other but would like to respect the spirit of the initial PR.

**_So whats the point of this PR at all._** To avoid hardcoding and passing values. This is simply cleaner.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
