### PR TITLE
add: (type definition) retriesCount

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,6 +47,7 @@ declare namespace fastifyReplyFrom {
     req: FastifyRequest<RequestGenericInterface, RawServerBase>;
     res: FastifyReply<RawServerBase>;
     attempt: number;
+    retriesCount: number;
     getDefaultDelay: () => number | null;
   }
   export interface FastifyReplyFromHooks {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -91,7 +91,7 @@ async function main() {
   instance.get("/http2", (request, reply) => {
       reply.from("/", {
           method: "POST",
-          retryDelay: ({err, req, res, attempt, getDefaultDelay}) => {
+          retryDelay: ({err, req, res, attempt, retriesCount, getDefaultDelay }) => {
               const defaultDelay = getDefaultDelay();
               if (defaultDelay) return defaultDelay;
 


### PR DESCRIPTION
Forgot to add the type definition for retriesCount added to the callback into my last PR. My mistake !

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
