### PR TITLE
build(deps): replace tiny-lru with toad-cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const { lru } = require('tiny-lru')
+const { LruMap } = require('toad-cache')
 const querystring = require('fast-querystring')
 const fastContentTypeParse = require('fast-content-type-parse')
 const Stream = require('node:stream')
@@ -32,7 +32,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
   const retryMethods = new Set(opts.retryMethods || [
     'GET', 'HEAD', 'OPTIONS', 'TRACE'])
 
-  const cache = opts.disableCache ? undefined : lru(opts.cacheURLs || 100)
+  const cache = opts.disableCache ? undefined : new LruMap(opts.cacheURLs || 100)
   const base = opts.base
   const requestBuilt = buildRequest({
     http: opts.http,

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "fast-querystring": "^1.0.0",
     "fastify-plugin": "^4.0.0",
     "pump": "^3.0.0",
-    "tiny-lru": "^11.0.0",
+    "toad-cache": "^3.7.0",
     "undici": "^5.19.1"
   },
   "pre-commit": [


### PR DESCRIPTION
This brings `fastify-reply-from` in line with `fastify`, `fastify-cigtm` and `fastify-rate-limit`, by switching to toad-cache, which is faster than tiny-lry, and to a map-based (as opposed to object-based) cache, which is faster for string keys.

See [benchmark](https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/cache-get-inmemory-string/_results/results.md) results.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
