### PR TITLE
fix: DELETE requests should not call stream.end

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -204,7 +204,8 @@ function buildRequest (opts) {
       ...stripHttp1ConnectionHeaders(opts.headers)
     }, http2Opts.requestOptions)
     const isGet = opts.method === 'GET' || opts.method === 'get'
-    if (!isGet) {
+    const isDelete = opts.method === 'DELETE' || opts.method === 'delete'
+    if (!isGet && !isDelete) {
       end(req, opts.body, done)
     }
     req.setTimeout(http2Opts.requestTimeout, () => {

--- a/test/full-delete-http2.test.js
+++ b/test/full-delete-http2.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const got = require('got')
+
+test('http -> http2', async function (t) {
+  const instance = Fastify()
+
+  t.teardown(instance.close.bind(instance))
+
+  const target = Fastify({
+    http2: true
+  })
+
+  target.delete('/', (request, reply) => {
+    t.pass('request proxied')
+    reply.code(200).header('x-my-header', 'hello!').send({
+      hello: 'world'
+    })
+  })
+
+  instance.delete('/', (request, reply) => {
+    reply.from()
+  })
+
+  t.teardown(target.close.bind(target))
+
+  await target.listen({ port: 0 })
+
+  instance.register(From, {
+    base: `http://localhost:${target.server.address().port}`,
+    http2: true
+  })
+
+  await instance.listen({ port: 0 })
+
+  const { headers, body, statusCode } = await got(
+    `http://localhost:${instance.server.address().port}`,
+    {
+      method: 'DELETE',
+      responseType: 'json'
+    }
+  )
+  t.equal(statusCode, 200)
+  t.equal(headers['x-my-header'], 'hello!')
+  t.match(headers['content-type'], /application\/json/)
+  t.same(body, { hello: 'world' })
+})


### PR DESCRIPTION
It appears that `DELETE` streams behave the same as `GET` streams in that they are not writable (immediately ended?), so calling `.end` on the stream throws a `write after end` error ([related issue](https://github.com/fastify/fastify-http-proxy/issues/253)).

I cannot find this documented anywhere in HTTP2 spec or in NodeJS HTTP2 module (aside from the `endStream` header, and `http2stream.endAfterHeaders` which don't seem to affect anything here - can anyone share insight?).

This PR simply adds the `DELETE` method to a check on whether or not to end the stream. The change fixes https://github.com/fastify/fastify-http-proxy/issues/253.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
