### PR TITLE
feat: pass request to the queryString function

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ server.register(fastifyHttpProxy, {
 });
 ```
 
-#### `queryString` or `queryString(search, reqUrl)`
+#### `queryString` or `queryString(search, reqUrl, request)`
 
 Replaces the original querystring of the request with what is specified.
 This will be passed to

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
     const sourceHttp2 = req.httpVersionMajor === 2
     const headers = sourceHttp2 ? filterPseudoHeaders(req.headers) : { ...req.headers }
     headers.host = url.host
-    const qs = getQueryString(url.search, req.url, opts)
+    const qs = getQueryString(url.search, req.url, opts, this.request)
     let body = ''
 
     if (opts.body !== undefined) {
@@ -227,9 +227,9 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
   name: '@fastify/reply-from'
 })
 
-function getQueryString (search, reqUrl, opts) {
+function getQueryString (search, reqUrl, opts, request) {
   if (typeof opts.queryString === 'function') {
-    return '?' + opts.queryString(search, reqUrl)
+    return '?' + opts.queryString(search, reqUrl, request)
   }
 
   if (opts.queryString) {

--- a/test/full-querystring-rewrite-option-function-request.test.js
+++ b/test/full-querystring-rewrite-option-function-request.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('node:http')
+const get = require('simple-get').concat
+const querystring = require('node:querystring')
+
+const instance = Fastify()
+
+instance.addHook('preHandler', (request, reply, done) => {
+  request.addedVal = 'test'
+  done()
+})
+
+t.plan(10)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  t.equal(req.url, '/world?q=test')
+  res.statusCode = 205
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('x-my-header', 'hello!')
+  res.end('hello world')
+})
+
+instance.get('/hello', (request, reply) => {
+  reply.from(`http://localhost:${target.address().port}/world?a=b`, {
+    queryString (search, reqUrl, request) {
+      return querystring.stringify({ q: request.addedVal })
+    }
+  })
+})
+
+t.teardown(target.close.bind(target))
+
+target.listen({ port: 0 }, (err) => {
+  t.error(err)
+
+  instance.register(From)
+
+  instance.listen({ port: 0 }, (err) => {
+    t.error(err)
+
+    get(`http://localhost:${instance.server.address().port}/hello?a=b`, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.equal(res.headers['x-my-header'], 'hello!')
+      t.equal(res.statusCode, 205)
+      t.equal(data.toString(), 'hello world')
+    })
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,7 +40,11 @@ declare module "fastify" {
 
 type FastifyReplyFrom = FastifyPluginCallback<fastifyReplyFrom.FastifyReplyFromOptions>
 declare namespace fastifyReplyFrom {
-  type QueryStringFunction = (search: string | undefined, reqUrl: string) => string;
+  type QueryStringFunction = (
+    search: string | undefined,
+    reqUrl: string,
+    request: FastifyRequest<RequestGenericInterface, RawServerBase>
+  ) => string;
 
   export type RetryDetails = {
     err: Error;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -111,7 +111,13 @@ async function main() {
           },
           onError(reply: FastifyReply<RawServerBase>, error) {
               return reply.send(error.error);
-          }
+          },
+          queryString(search, reqUrl, request) {
+              expectType<string | undefined>(search);
+              expectType<string>(reqUrl);
+              expectType<FastifyRequest<RequestGenericInterface, RawServerBase>>(request);
+              return '';
+          },
       });
   });
 


### PR DESCRIPTION
Pass the request to the queryString function in the same way that rewriteRequestHeaders has access to the request object.

Fixes: #364

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
