### PR TITLE
fix: return 502 on invalid upstream status code

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,3 +12,4 @@ module.exports.ConnectionResetError = createError('ECONNRESET', 'Connection Rese
 module.exports.ConnectTimeoutError = createError('UND_ERR_CONNECT_TIMEOUT', 'Connect Timeout Error', 500)
 module.exports.UndiciSocketError = createError('UND_ERR_SOCKET', 'Undici Socket Error', 500)
 module.exports.InternalServerError = createError('FST_REPLY_FROM_INTERNAL_SERVER_ERROR', '%s', 500)
+module.exports.BadGatewayError = createError('FST_REPLY_FROM_BAD_GATEWAY', 'Bad Gateway', 502)

--- a/test/on-invalid-upstream-response.test.js
+++ b/test/on-invalid-upstream-response.test.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('node:http')
+const get = require('simple-get').concat
+
+const instance = Fastify()
+instance.register(From)
+
+t.plan(8)
+t.teardown(instance.close.bind(instance))
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'GET')
+  res.statusCode = 888
+  res.end('non-standard status code')
+})
+
+instance.get('/', (_, reply) => {
+  reply.from(`http://localhost:${target.address().port}`, {
+    onResponse: (_, reply, res) => {
+      t.equal(res.statusCode, 888)
+    }
+  })
+})
+
+t.teardown(target.close.bind(target))
+
+instance.listen({ port: 0 }, (err) => {
+  t.error(err)
+
+  target.listen({ port: 0 }, (err) => {
+    t.error(err)
+
+    get(
+      `http://localhost:${instance.server.address().port}`,
+      (err, res, data) => {
+        t.error(err)
+        t.equal(res.statusCode, 502)
+        t.same(JSON.parse(data), {
+          statusCode: 502,
+          code: 'FST_REPLY_FROM_BAD_GATEWAY',
+          error: 'Bad Gateway',
+          message: 'Bad Gateway'
+        })
+      }
+    )
+  })
+})


### PR DESCRIPTION
Map upstream responses with an invalid status code to a `502 Bad Gateway` response.

Fixes https://github.com/fastify/fastify-reply-from/issues/374

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
