### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,7 +1,7 @@
 import fastify, { FastifyReply, FastifyRequest, RawReplyDefaultExpression, RawServerBase, RequestGenericInterface, RouteGenericInterface } from "fastify";
-import * as http from 'http';
+import * as http from 'node:http';
 import { IncomingHttpHeaders } from "http2";
-import * as https from 'https';
+import * as https from 'node:https';
 import { AddressInfo } from "net";
 import { expectType } from 'tsd';
 import replyFrom, { FastifyReplyFromOptions } from "..";


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.