### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@sinonjs/fake-timers": "^13.0.1",
     "@types/node": "^22.0.0",
     "@types/tap": "^18.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "form-data": "^4.0.0",
     "got": "^11.8.6",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.