### PR TITLE
types: Allow to pass any requestable undici instance

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ import {
   AgentOptions as SecureAgentOptions,
   RequestOptions as SecureRequestOptions
 } from 'https'
-import { Pool, ProxyAgent } from 'undici'
+import { Pool, ProxyAgent, Dispatcher } from 'undici'
 
 declare module 'fastify' {
   interface FastifyReply {
@@ -104,7 +104,7 @@ declare namespace fastifyReplyFrom {
     disableCache?: boolean;
     http?: HttpOptions;
     http2?: Http2Options | boolean;
-    undici?: Pool.Options & { proxy?: string | URL | ProxyAgent.Options };
+    undici?: Pool.Options & { proxy?: string | URL | ProxyAgent.Options } | { request: Dispatcher['request'] };
     contentTypesToEncode?: string[];
     retryMethods?: (HTTPMethods | 'TRACE')[];
     maxRetriesOn503?: number;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,6 +4,7 @@ import { IncomingHttpHeaders } from 'http2'
 import * as https from 'node:https'
 import { AddressInfo } from 'net'
 import { expectType } from 'tsd'
+import { Agent, Client, Dispatcher, Pool } from 'undici'
 import replyFrom, { FastifyReplyFromOptions } from '..'
 // @ts-ignore
 import tap from 'tap'
@@ -157,6 +158,34 @@ async function main () {
     }
   })
   await undiciInstance.ready()
+
+  const undiciInstanceAgent = fastify()
+  undiciInstance.register(replyFrom, {
+    base: 'http://example2.com',
+    undici: new Agent()
+  })
+  await undiciInstanceAgent.ready()
+
+  const undiciInstancePool = fastify()
+  undiciInstance.register(replyFrom, {
+    base: 'http://example2.com',
+    undici: new Pool('http://example2.com')
+  })
+  await undiciInstancePool.ready()
+
+  const undiciInstanceClient = fastify()
+  undiciInstance.register(replyFrom, {
+    base: 'http://example2.com',
+    undici: new Client('http://example2.com')
+  })
+  await undiciInstanceClient.ready()
+
+  const undiciInstanceDispatcher = fastify()
+  undiciInstance.register(replyFrom, {
+    base: 'http://example2.com',
+    undici: new Dispatcher()
+  })
+  await undiciInstanceDispatcher.ready()
 
   tap.pass('done')
   tap.end()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

`undici` accepts any kind of Dispatcher, however this was not reflected in types

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [~] documentation is changed or added (already covered by documentation) 
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
