### PR TITLE
bug fix for #424 with test

### DIFF
--- a/test/http2-canceled-streams-cleanup.test.js
+++ b/test/http2-canceled-streams-cleanup.test.js
@@ -1,0 +1,117 @@
+'use strict'
+
+const t = require('node:test')
+const Fastify = require('fastify')
+const From = require('..')
+const fs = require('node:fs')
+const path = require('node:path')
+const http2 = require('node:http2')
+const { once } = require('events')
+const certs = {
+  key: fs.readFileSync(path.join(__dirname, 'fixtures', 'fastify.key')),
+  cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'fastify.cert'))
+}
+const { HTTP2_HEADER_STATUS, HTTP2_HEADER_PATH } = http2.constants
+
+function makeRequest (client, counter) {
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController()
+    const signal = controller.signal
+    const cancelRequestEarly = counter % 2 === 0  // cancel early every other request
+    let responseCounter = 0
+
+    const clientStream = client.request({ [HTTP2_HEADER_PATH]: '/' }, { signal })
+
+    clientStream.end()
+
+    clientStream.on('data', chunk => {
+      const s = chunk.toString()
+      // Sometimes we just get NGHTTP2_ENHANCE_YOUR_CALM internal server errors
+      if (s.startsWith('{"statusCode":500')) reject(new Error('got internal server error'))
+      else responseCounter++
+    })
+
+    clientStream.on('error', err => {
+      if (err instanceof Error && err.name === 'AbortError') {
+        if (responseCounter === 0 && !cancelRequestEarly) {
+          // if we didn´t cancel early we should have received at least one response from the target
+          // if not, this indicated the stream resource leak
+          reject(new Error('no response'))
+        } else resolve()
+      } else reject(err instanceof Error ? err : new Error(JSON.stringify(err)))
+    })
+
+    clientStream.on('end', () => { resolve() })
+
+    setTimeout(() => { controller.abort() }, cancelRequestEarly ? 20 : 200)
+  })
+}
+
+const httpsOptions = {
+  ...certs,
+  settings: {
+    maxConcurrentStreams: 10, // lower the default so we can reproduce the problem quicker
+  }
+}
+
+t.test('http2 -> http2', async (t) => {
+  const instance = Fastify({
+    http2: true,
+    https: httpsOptions
+  })
+
+  t.after(() => instance.close())
+
+  const target = http2.createSecureServer(httpsOptions)
+
+  target.on('stream', (stream, _headers, _flags) => {
+    let counter = 0
+    let headerSent = false
+
+    // deliberately delay sending the headers
+    const sendData = () => {
+      if (!headerSent) {
+        stream.respond({ [HTTP2_HEADER_STATUS]: 200, })
+        headerSent = true
+      }
+      stream.write(counter + '\n')
+      counter = counter + 1
+    }
+
+    const intervalId = setInterval(sendData, 50)
+
+    // ignore write after end errors
+    stream.on('error', _err => { })
+
+    stream.on('close', () => { clearInterval(intervalId) })
+  })
+
+  instance.get('/', (_request, reply) => {
+    reply.from()
+  })
+
+  t.after(() => target.close())
+
+  target.listen()
+  await once(target, 'listening')
+
+  instance.register(From, {
+    base: `https://localhost:${target.address().port}`,
+    http2: true,
+    rejectUnauthorized: false
+  })
+
+  const url = await instance.listen({ port: 0 })
+
+  const client = http2.connect(url, {
+    rejectUnauthorized: false,
+  })
+
+  // see https://github.com/fastify/fastify-reply-from/issues/424
+  // without the bug fix this will fail after about 15 requests
+  for (let i = 0; i < 30; i++) { await makeRequest(client, i) }
+
+  client.close()
+  instance.close()
+  target.close()
+})


### PR DESCRIPTION
bug fix for issue #424 

Streams were leaking when a client canceled requests before fastify-reply-request got a response from the upstream server.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
