### PR TITLE
Improve typing and usage of `getDefaultDelay`

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Given example
 ```js
    const customRetryLogic = ({err, req, res, attempt, getDefaultRetry}) => {
     //If this block is not included all non 500 errors will not be retried
-    const defaultDelay = getDefaultDelay();
+    const defaultDelay = getDefaultDelay(req, res, err, attempt);
     if (defaultDelay) return defaultDelay();
 
     //Custom retry logic

--- a/test/retry-with-a-custom-handler.test.js
+++ b/test/retry-with-a-custom-handler.test.js
@@ -55,8 +55,8 @@ test('a 500 status code with no custom handler should fail', async (t) => {
 })
 
 test("a server 500's with a custom handler and should revive", async (t) => {
-  const customRetryLogic = ({ req, res, getDefaultDelay }) => {
-    const defaultDelay = getDefaultDelay()
+  const customRetryLogic = ({ req, res, err, attempt, getDefaultDelay }) => {
+    const defaultDelay = getDefaultDelay(req, res, err, attempt)
     if (defaultDelay) return defaultDelay
 
     if (res && res.statusCode === 500 && req.method === 'GET') {
@@ -92,9 +92,9 @@ test('custom retry does not invoke the default delay causing a 501', async (t) =
 })
 
 test('custom retry delay functions can invoke the default delay', async (t) => {
-  const customRetryLogic = ({ req, res, getDefaultDelay }) => {
+  const customRetryLogic = ({ req, res, err, attempt, getDefaultDelay }) => {
     // registering the default retry logic for non 500 errors if it occurs
-    const defaultDelay = getDefaultDelay()
+    const defaultDelay = getDefaultDelay(req, res, err, attempt)
     if (defaultDelay) return defaultDelay
 
     if (res && res.statusCode === 500 && req.method === 'GET') {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,12 @@ declare namespace fastifyReplyFrom {
     res: FastifyReply<RouteGenericInterface, RawServerBase>;
     attempt: number;
     retriesCount: number;
-    getDefaultDelay: () => number | null;
+    getDefaultDelay: (
+      req: FastifyRequest<RequestGenericInterface, RawServerBase>,
+      res: FastifyReply<RouteGenericInterface, RawServerBase>,
+      err: Error,
+      retries: number,
+    ) => number | null;
   }
 
   export type RawServerResponse<T extends RawServerBase> = RawReplyDefaultExpression<T> & {
@@ -64,7 +69,7 @@ declare namespace fastifyReplyFrom {
   export interface FastifyReplyFromHooks {
     queryString?: { [key: string]: unknown } | QueryStringFunction;
     contentType?: string;
-    retryDelay?: (details: RetryDetails) => {} | null;
+    retryDelay?: (details: RetryDetails) => number | null;
     retriesCount?: number;
     onResponse?: (
       request: FastifyRequest<RequestGenericInterface, RawServerBase>,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -103,8 +103,8 @@ async function main () {
   instance.get('/http2', (_request, reply) => {
     reply.from('/', {
       method: 'POST',
-      retryDelay: ({ req, res, getDefaultDelay }) => {
-        const defaultDelay = getDefaultDelay()
+      retryDelay: ({ req, res, err, attempt, getDefaultDelay }) => {
+        const defaultDelay = getDefaultDelay(req, res, err, attempt)
         if (defaultDelay) return defaultDelay
 
         if (res && res.statusCode === 500 && req.method === 'GET') {


### PR DESCRIPTION
Based on [implementation](https://github.com/fastify/fastify-reply-from/blob/cd2ba083e4a4e8085dc973edb8c5e622efaf830e/index.js#L151C3-L151C53) `getDefaultDelay` typing and usage is inaccurate.


Addressing topic from:
* https://github.com/fastify/fastify-reply-from/pull/337#discussion_r2262119652
* https://github.com/fastify/fastify-reply-from/pull/337#discussion_r2262121241

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
