### PR TITLE
fix: preserve undici agent by default

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -53,7 +53,7 @@ function buildRequest (opts) {
   const isBalanced = Array.isArray(opts.base) && opts.base.length > 1
   const undiciOpts = opts.undici || {}
   const globalAgent = opts.globalAgent
-  const destroyAgent = opts.destroyAgent
+  const destroyAgent = opts.destroyAgent || false
   let http2Client
   let undiciAgent
   let undiciInstance

--- a/test/undici-no-destroy.test.js
+++ b/test/undici-no-destroy.test.js
@@ -27,3 +27,25 @@ test('destroyAgent false', async (t) => {
   await instance.ready()
   await instance.close()
 })
+
+test('destroyAgent default false', async (t) => {
+  const mockAgent = new undici.Agent()
+  mockAgent.destroy = () => {
+    t.fail()
+  }
+  const instance = Fastify()
+
+  t.after(() => instance.close())
+
+  instance.get('/', (_request, reply) => {
+    reply.from()
+  })
+
+  instance.register(From, {
+    base: 'http://localhost:4242',
+    undici: mockAgent
+  })
+
+  await instance.ready()
+  await instance.close()
+})


### PR DESCRIPTION
Documentation states destroyAgent defaults to false but the option was undefined when omitted, causing custom agents to be destroyed. Explicitly default the option to false and cover it with a regression test. Fixes #444.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
