### PR TITLE
feat: preserve undici agent by default

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -53,7 +53,7 @@ function buildRequest (opts) {
   const isBalanced = Array.isArray(opts.base) && opts.base.length > 1
   const undiciOpts = opts.undici || {}
   const globalAgent = opts.globalAgent
-  const destroyAgent = opts.destroyAgent
+  const destroyAgent = opts.destroyAgent || false
   let http2Client
   let undiciAgent
   let undiciInstance
@@ -104,6 +104,11 @@ function buildRequest (opts) {
   }
 
   function close () {
+    // Always destroy http2 client (internal implementation detail)
+    if (http2Client) {
+      http2Client.destroy()
+    }
+
     if (globalAgent || destroyAgent === false) {
       return
     }
@@ -114,8 +119,6 @@ function buildRequest (opts) {
     } else if (!isHttp2) {
       agents['http:'].destroy()
       agents['https:'].destroy()
-    } else if (http2Client) {
-      http2Client.destroy()
     }
   }
 

--- a/test/undici-no-destroy.test.js
+++ b/test/undici-no-destroy.test.js
@@ -27,3 +27,25 @@ test('destroyAgent false', async (t) => {
   await instance.ready()
   await instance.close()
 })
+
+test('destroyAgent default false', async (t) => {
+  const mockAgent = new undici.Agent()
+  mockAgent.destroy = () => {
+    t.fail()
+  }
+  const instance = Fastify()
+
+  t.after(() => instance.close())
+
+  instance.get('/', (_request, reply) => {
+    reply.from()
+  })
+
+  instance.register(From, {
+    base: 'http://localhost:4242',
+    undici: mockAgent
+  })
+
+  await instance.ready()
+  await instance.close()
+})


### PR DESCRIPTION
Documentation states destroyAgent defaults to false but the option was undefined when omitted, causing custom agents to be destroyed. Explicitly default the option to false and cover it with a regression test.

Fixes #444.

This PR lifts the fix from #446 which had CI issues.