### PR TITLE
fix: avoid trailing `?` when queryString option resolves to empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,11 +250,13 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
 
 function getQueryString (search, reqUrl, opts, request) {
   if (typeof opts.queryString === 'function') {
-    return '?' + opts.queryString(search, reqUrl, request)
+    const qs = opts.queryString(search, reqUrl, request)
+    return qs ? '?' + qs : ''
   }
 
   if (opts.queryString) {
-    return '?' + querystring.stringify(opts.queryString)
+    const qs = querystring.stringify(opts.queryString)
+    return qs ? '?' + qs : ''
   }
 
   if (search.length > 0) {

--- a/test/full-querystring-rewrite-option-empty-object.test.js
+++ b/test/full-querystring-rewrite-option-empty-object.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const t = require('node:test')
+const Fastify = require('fastify')
+const { request } = require('undici')
+const From = require('..')
+const http = require('node:http')
+
+const instance = Fastify()
+
+t.test('queryString empty object should not append trailing ?', async (t) => {
+  t.plan(4)
+  t.after(() => instance.close())
+
+  const target = http.createServer((req, res) => {
+    t.assert.ok('request proxied')
+    t.assert.strictEqual(req.url, '/world')
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'text/plain')
+    res.end('hello world')
+  })
+
+  instance.get('/hello', (_request, reply) => {
+    reply.from(`http://localhost:${target.address().port}/world`, {
+      queryString: {}
+    })
+  })
+
+  t.after(() => target.close())
+
+  await new Promise(resolve => target.listen({ port: 0 }, resolve))
+
+  instance.register(From)
+
+  await new Promise(resolve => instance.listen({ port: 0 }, resolve))
+
+  const result = await request(`http://localhost:${instance.server.address().port}/hello`)
+
+  t.assert.strictEqual(result.statusCode, 200)
+  t.assert.strictEqual(await result.body.text(), 'hello world')
+})

--- a/test/full-querystring-rewrite-option-function-empty.test.js
+++ b/test/full-querystring-rewrite-option-function-empty.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const t = require('node:test')
+const Fastify = require('fastify')
+const { request } = require('undici')
+const From = require('..')
+const http = require('node:http')
+
+const instance = Fastify()
+
+t.test('queryString function returning empty string should not append trailing ?', async (t) => {
+  t.plan(4)
+  t.after(() => instance.close())
+
+  const target = http.createServer((req, res) => {
+    t.assert.ok('request proxied')
+    t.assert.strictEqual(req.url, '/world')
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'text/plain')
+    res.end('hello world')
+  })
+
+  instance.get('/hello', (_request, reply) => {
+    reply.from(`http://localhost:${target.address().port}/world`, {
+      queryString () {
+        return ''
+      }
+    })
+  })
+
+  t.after(() => target.close())
+
+  await new Promise(resolve => target.listen({ port: 0 }, resolve))
+
+  instance.register(From)
+
+  await new Promise(resolve => instance.listen({ port: 0 }, resolve))
+
+  const result = await request(`http://localhost:${instance.server.address().port}/hello`)
+
+  t.assert.strictEqual(result.statusCode, 200)
+  t.assert.strictEqual(await result.body.text(), 'hello world')
+})


### PR DESCRIPTION
## Summary

When the `queryString` option resolves to an empty string, `getQueryString` unconditionally prepends `?`, resulting in a trailing `?` on the upstream request path (e.g. `/path?` instead of `/path`). 

This affects both forms:
- **Function form**: `'?' + opts.queryString(...)` when the function returns `''`
- **Object form**: `'?' + querystring.stringify(opts.queryString)` when the object is empty `{}`

This is inconsistent with the default code path (no `queryString` option), which correctly returns `''` when there's no query string.

## Fix

Guard both paths to only prepend `?` when the result is non-empty:

```js
  const qs = opts.queryString(search, reqUrl, request)
  return qs ? '?' + qs : ''
```

Closes https://github.com/fastify/fastify-reply-from/issues/458
