### PR TITLE
chore: remove `@types/tap`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@fastify/multipart": "^10.0.0",
     "@sinonjs/fake-timers": "^15.0.0",
     "@types/node": "^25.0.3",
-    "@types/tap": "^18.0.0",
     "c8": "^11.0.0",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",


### PR DESCRIPTION
This PR is a follow up of #418. Seems like `@types/tap` were supposed to be removed together with `tap`.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
