### PR TITLE
Use `content-type` fast parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const http2 = require('node:http2')
 const fp = require('fastify-plugin')
 const { LruMap } = require('toad-cache')
 const querystring = require('fast-querystring')
-const fastContentTypeParse = require('fast-content-type-parse')
+const contentTypeParse = require('content-type').parse
 const Stream = require('node:stream')
 const buildRequest = require('./lib/request')
 const {
@@ -133,7 +133,7 @@ const fastifyReplyFrom = fp(function from (fastify, opts, next) {
         // Per RFC 7231 §3.1.1.5 if this header is not present we MAY assume application/octet-stream
         let contentType = 'application/octet-stream'
         if (req.headers['content-type']) {
-          const plainContentType = fastContentTypeParse.parse(req.headers['content-type'])
+          const plainContentType = contentTypeParse(req.headers['content-type'], { parameters: false })
           contentType = plainContentType.type
         }
 

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
   },
   "dependencies": {
     "@fastify/error": "^4.0.0",
+    "content-type": "^2.0.0",
     "end-of-stream": "^1.4.4",
-    "fast-content-type-parse": "^3.0.0",
     "fast-querystring": "^1.1.2",
     "fastify-plugin": "^5.0.1",
     "toad-cache": "^3.7.0",


### PR DESCRIPTION
Preamble: I know `fast-content-type-parse` is intended to be a Fastify fork of `content-type` and is likely forked for historical reasons, but I recently released a `content-type@2` and the changes seemed relevant to this package. Mostly because there's no need to parse parameters at all.

Changes `fast-content-type-parse` to use `content-type` with `parameters: false` to extract the `content-type` parameter.

However, the parser in `content-type` no longer validates during parse (designed to be lenient/fast) so there is a minor behavior change with invalid MIME types. If you sent something like `foo` it would currently throw during `.parse` but in this change it'll forward `foo` along.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
